### PR TITLE
docs(resolvers): restructure for 6-tab detail page + add Upgrade chan…

### DIFF
--- a/cs/resolvers.rst
+++ b/cs/resolvers.rst
@@ -1,12 +1,12 @@
 Správa resolveru
 ================
 
-V záložce **Resolvery** je přehled vytvořených resolverů. Správce může upravovat konfiguraci, nasazovat aktualizace a instalovat nové resolvery.
+V záložce **Resolvery** je přehled vytvořených resolverů. Správce může upravovat konfiguraci, nasazovat aktualizace, instalovat nové resolvery a sledovat detailní provozní a výkonnostní metriky každého resolveru.
 
 Přehled resolverů
 -----------------
 
-V hlavním přehledu resolverů jsou dlaždice s podrobnostmi o resolveru. Přehled obsahuje informace o operačním systému a zdrojích jako využití CPU, paměti a HDD. Je zde také stav komunikačního kanálu mezi resolverem a cloudem označený barevnou tečkou.
+V hlavním přehledu resolverů jsou dlaždice s podrobnostmi o resolveru. Každá dlaždice obsahuje název resolveru a jeho ID, název hostitele, používanou verzi, jednu či více IP adres, indikátor stavu operačního systému a aktuální využití zdrojů (CPU, RAM a HDD). Stav komunikačního kanálu mezi resolverem a cloudem je označen barevnou tečkou vedle popisku **Stav**.
 
 Resolver se může nacházet v jednom z těchto stavů:
 
@@ -15,6 +15,28 @@ Resolver se může nacházet v jednom z těchto stavů:
 * **Nedostupný**: Resolver ztratil spojení se službou Whalebone Cloud. Tento stav nemá vliv na překlad DNS, nicméně resolver nemůže získávat aktualizace databáze hrozeb a nemusí reagovat na změny zásad nebo konfigurace iniciované z portálu.
 * **Upgrading**: Resolveru byl vydán příkaz k aktualizaci. Tento stav by neměl přetrvávat déle než několik minut.
 * **Není nainstalován**: Resolver ještě nebyl nainstalován.
+
+Nad dlaždicemi resolverů jsou čtyři grafové záložky agregující metriky napříč všemi lokálními resolvery:
+
+* **Časy odezvy** — rozdělení latence DNS dotazů do skupin (1 ms / 10 ms / 50 ms / 100 ms / 250 ms / 500 ms / 1000 ms / 1500 ms / pomalé).
+* **Provoz** — absolutní objem dotazů v čase.
+* **Provoz %** — relativní podíl na resolver.
+* **Denní požadavky** — celkový denní počet požadavků.
+
+.. note:: Pokud zatím nemáte žádný nainstalovaný resolver, na stránce se zobrazí výzva **Vytvořte si první resolver** s tlačítkem **Vytvořit nový**. Postup instalace najdete v sekci :doc:`local_resolver`.
+
+Akce nad resolverem
+~~~~~~~~~~~~~~~~~~~
+
+Každá dlaždice resolveru má v pravém horním rohu nabídku se třemi tečkami obsahující následující akce:
+
+* **Upravit resolver** — otevře detail resolveru (lze také kliknout na název resolveru).
+* **Vymazat keš pro doménu** — vyprázdní záznamy keše resolveru pro zadanou doménu.
+* **Vymazat keš resolveru** — vyprázdní celou DNS keš na resolveru.
+* **Trasovat doménu** — spustí trasování překladu domény z tohoto resolveru.
+* **Je tato doména blokována?** — ověří, zda by zadaná doména byla blokována stávající politikou.
+* **Změnit název** — přejmenuje resolver v portálu.
+* **Smazat resolver** — odstraní resolver z portálu. Tato akce neodinstaluje software na hostiteli; viz :doc:`uninstalling`.
 
 Nahrání konfigurace
 -------------------
@@ -28,18 +50,69 @@ Na následující animaci uvidíte nahrání konfigurace na resolver.
 .. image:: ./img/lrv2-deployconfig.gif
    :align: center
 
-Nastevení bezpečnostní politky pro jednotlivé segmenty
-------------------------------------------------------
+Detail resolveru
+----------------
 
-Zásady zabezpečení a obsahu lze granulárním způsobem přiřadit různým segmentům sítě.
+Kliknutím na název resolveru (nebo na **Upravit resolver** v nabídce na dlaždici) se otevře stránka s detailem resolveru. Stránka je rozdělena do šesti sekcí v levém menu:
 
-Nastavení se vztahuje na jednotlivé resolvery a lze je nakonfigurovat v části **Resolvery** → ``Název resolveru`` → **Přiřazení politik**.
+* :ref:`statistiky`
+* :ref:`prirazeni-politik`
+* :ref:`pokrocila-konfigurace`
+* :ref:`aktualizace`
+* :ref:`protokol-akci`
+* :ref:`integrace`
 
-.. note:: Konfigurace se vztahuje na zvlášť **pro každý resolver**. V případě, že chcete konfiguraci použít pro více resolverů, upravte konfiguraci u všech resolverů.
+Pravý sloupec zobrazuje **Název hostitele**, **Rozhraní** s přiřazenými IP adresami, **Platformu** (operační systém) a **Verzi** pro referenci.
 
-Bezpečnostní politiky lze aplikovat přidáním rozsahů IP ve vstupních oknech:
+.. _statistiky:
 
-Přiřazení bezpečnostní politiky.
+Statistiky
+~~~~~~~~~~
+
+Výchozí pohled při otevření detailu resolveru. Obsahuje živé provozní grafy:
+
+* **Časy odezvy resolveru** — dotazy rozdělené podle latence (1 ms / 10 ms / 50 ms / 100 ms / 250 ms / 500 ms / 1000 ms / 1500 ms / pomalé).
+* **Zdraví** — procento úspěšných kontrol zdraví v rámci pozorovaného intervalu.
+* **Vytížení CPU** — využití procesoru na hostiteli resolveru.
+* **Využití paměti / Swap / Disku** — metriky paměťové zátěže.
+* **Počet zápisů / čtení** — diskové vstupně-výstupní operace.
+* **Zapsané / přečtené bajty** — propustnost diskového I/O.
+* **Přijaté / odeslané pakety** — počítadla síťových paketů.
+* **Přijaté / odeslané bajty** — síťová propustnost.
+
+.. _prirazeni-politik:
+
+Přiřazení politik
+~~~~~~~~~~~~~~~~~
+
+Pohled **Přiřazení politik** sdružuje tři související nastavení.
+
+Nastavení blokační stránky
+""""""""""""""""""""""""""
+
+* **Umístění blokační stránky** — výběr mezi **Whalebone Cloud** (blokační stránky obsluhované Whalebone) a **On-premise lokální resolver** (blokační stránky obsluhované z hostitele resolveru). Při volbě **On-premise lokální resolver** se zobrazí dvě další pole:
+
+  * **IPv4 pro blokační stránku** — IPv4 adresa pro blokační stránku. Měla by být nastavena na veřejnou IP adresu resolveru.
+  * **IPv6 pro blokační stránku** — IPv6 adresa pro blokační stránku. Měla by být nastavena na veřejnou IP adresu resolveru.
+
+.. tip:: Blokační stránky jsou umístěny **přímo** na resolverech, takže je třeba použít IP adresy, které jsou inzerovány klientům. Klienti pak budou při blokování přesměrováni na IP adresu resolveru. Zajistěte, aby byly na firewallu přístupné porty 80 a 443.
+
+Strategie přiřazování politik
+"""""""""""""""""""""""""""""
+
+Volba **Přiřadit politiku podle IP** určuje, podle čeho resolver rozhoduje, jakou politiku aplikovat na DNS dotaz:
+
+* **Klient** — přiřazení podle IP adresy klienta. Použijte, pokud chcete politiky řízené IP rozsahy klientských zařízení (například odlišné politiky pro různé podsítě koncových uživatelů).
+* **Resolver** — přiřazení podle IP adresy resolveru. Použijte, pokud se klienti dostávají k Whalebone prostřednictvím vlastního DNS serveru a politika má být určena podle IP tohoto serveru.
+
+Tabulka přiřazení politik
+"""""""""""""""""""""""""
+
+Zásady zabezpečení a obsahu lze granulárním způsobem přiřadit různým segmentům sítě. Nastavení se vztahuje na jednotlivé resolvery a lze je nakonfigurovat v části **Resolvery** → ``Název resolveru`` → **Přiřazení politik**.
+
+.. note:: Konfigurace se vztahuje **na každý resolver zvlášť**. V případě, že chcete konfiguraci použít pro více resolverů, upravte konfiguraci u všech resolverů.
+
+Politiky lze aplikovat přidáním rozsahů IP ve vstupních polích:
 
 .. image:: ./img/add-policy.PNG
    :align: center
@@ -70,7 +143,7 @@ Vytvořili jsme 3 různé politiky:
 
    Politika s přísnějším blokováním
 
-.. note:: První možnost nastavení zásad je pro všechny nedefinované rozsahy. V případě různých zásad ovlivňujících stejný rozsah se použije ta, která je více granulární.
+.. note:: Výchozí politika je aplikována na všechny nedefinované rozsahy. V případě různých politik ovlivňujících stejný rozsah se použije ta granulárnější.
 
 Shrňme požadavky do následující tabulky:
 
@@ -82,55 +155,125 @@ Exception                 10.10.10.0/24
 Schools                   10.10.20.0/24 a 10.10.40.0/24
 ========================= ===============================
 
-Následující obrázek ukazuje proces přiřazování bezpečnostních politik k rozsahům.
+Následující obrázek ukazuje proces přiřazování politik k rozsahům:
 
 .. image:: ./img/policy_task.png
    :align: center
 
-.. note::  Po přidání politik k rozsahům je nutné kliknout na **Uložit do resolveru**, aby se přidání projevilo. Poté budou změny ověřeny a vyskakovací zpráva poskytne další informace.
+.. note:: Po přidání politik k rozsahům je nutné kliknout na **Uložit do resolveru**, aby se změny projevily. Poté budou změny ověřeny a vyskakovací zpráva poskytne další informace.
 
-Pro přiřazení dalších položek ke stávajícímu přiřazení lze přidat nový rozsah sítí pomocí **nového řádku** jako oddělovače.
+Pro přidání dalších položek ke stávajícímu přiřazení lze přidat nový rozsah sítě pomocí **nového řádku** jako oddělovače.
 
-V návaznosti na předchozí příklad, kdy bychom chtěli přidat podsíť ``10.10.30.0/24`` do bezpečnostní politiky **Exception**, tak tuto podsíť přidáme jako nový rozsah k existující bezpečnostní politice:
+V návaznosti na předchozí příklad, kdy bychom chtěli přidat podsíť ``10.10.30.0/24`` do bezpečnostní politiky **Exception**, tuto podsíť přidáme jako nový rozsah k existující politice:
 
 .. image:: ./img/add-range.gif
    :align: center
 
-Konfigurace blokačních stránek
-------------------------------
-
-Podobně jako zásady zabezpečení lze k určitým rozsahům přiřadit i různé blokační stránky.
-
-Prvním krokem je v detailu **Lokálního resolveru** v záložce **Přiřazení politik** v části **Nastavení blokační stránky**. Jsou zde dostupná dvě pole, do kterých je třeba vyplnit adresy IPv4 a IPv6 blokačních stránek.
-
-.. tip:: Blokační stránky jsou umístěny **přímo** na resolverech, takže je třeba použít IP adresy, které jsou inzerovány klientům. Klienti pak budou při blokování přesměrováni na IP adresu resolveru. Zajistěte, aby byly na firewallu přístupné porty 80 a 443.
-
 Pro každý přidaný rozsah IP adres je v rozevírací nabídce uvedena přiřazená blokační stránka.
 
 .. figure:: ./img/blocking-page-assign.png
-   :alt: Přiřazení blokační stránky k adresnímu rozsahu.
+   :alt: Přiřazení blokační stránky k adresnímu rozsahu
    :align: center
 
-.. important:: První položka v **Policy Assignment** je považována za výchozí. V případě, že klient přistupuje k resolveru z nedefinovaného rozsahu IP, bude spadat pod politiku a blokační stránku z daného výchozího rozsahu.
+   Přiřazení blokační stránky k adresnímu rozsahu
 
-.. note:: Po provedení potřebných změn v nastavení stránky blokování zkontrolujte, zda je třeba nové nastavení nahrát na resolvery.
+.. important:: První položka v **Přiřazení politik** je považována za výchozí. V případě, že klient přistupuje k resolveru z nedefinovaného rozsahu IP, bude spadat pod politiku a blokační stránku z této výchozí položky.
 
-Aktualizace a obnovení resolveru
---------------------------------
+.. note:: Po provedení potřebných změn v nastavení blokační stránky zkontrolujte, zda je třeba nové nastavení nahrát na resolvery.
 
-Po vydání nové verze resolveru se v rozhraní pro správu resolveru zobrazí **modrý rámeček** s informací o dostupnosti nové verze.
+.. _pokrocila-konfigurace:
 
-.. image:: ./img/upgrade.png
-   :align: center
+Pokročilá konfigurace
+~~~~~~~~~~~~~~~~~~~~~
 
-Po kliknutí na odkaz **Upgrade k dispozici** budete přesěrováni na stránku s důležitými informace o nové verzi a tlačítkem na spuštění aktualizace.
+Pohled **Pokročilá konfigurace** zpřístupňuje technická nastavení na úrovni resolveru.
 
-.. image:: ./img/upgrade-2.png
-   :align: center
+* **Volba konfigurace DNS překladu** — vyberte profil DNS překladu, který se má použít na tento resolver. Profily se definují v sekci :doc:`dns_resolution`. Výchozím profilem je **Default DNS resolution**.
 
-Z této nabídky lze zahájit aktualizaci resolveru kliknutím na tlačítko **Aktualizujte resolver nyní**.
+V sekci **Expertní nastavení** (ve výchozím stavu sbalená) lze přepsat následující výchozí hodnoty:
 
-V případě, že instalace nové verze nepřinese očekávaný výsledek, je možné se kdykoli vrátit k předchozí verzi na kartě **Vrácení změn**:
+* **Vypnout logování DNS** — když je zapnuto, resolver nezaznamenává lokální záznamy dotazů. Používejte pouze pokud to vyžaduje objem logů nebo požadavky na soukromí; mnoho funkcí (Hrozby, Obsah) na těchto záznamech závisí.
+* **Upravit velikost rotace logů** — přepíše výchozí velikost pro rotaci log souborů resolveru.
+* **Cíle syslogu** — přidá jeden či více vzdálených syslog cílů, na které bude resolver přeposílat logy. Dostupné log soubory a formáty popisuje sekce :doc:`syslog_integration`.
+* **Počet procesů resolveru** — přepíše počet pracovních procesů pro překlad na hostiteli.
+* **Naslouchat na všech IP adresách** — je-li zapnuto (výchozí), resolver naslouchá na všech IP adresách všech rozhraní hostitele. Vypněte pro omezení naslouchání pouze na vybranou podmnožinu (konfiguruje se přes Whalebone podporu).
+
+Kliknutím na **Uložit** uložíte změny. Stejně jako u jiných změn konfigurace je vyžadováno nasazení na resolver.
+
+.. _aktualizace:
+
+Aktualizace
+~~~~~~~~~~~
+
+Pohled **Aktualizace** zobrazuje aktuální verzi resolveru a datum vydání a je rozdělen do tří podzáložek.
+
+**Dostupná aktualizace**
+    Ukazuje, zda je dostupná novější verze v aktuálním kanálu. Pokud je resolver aktuální, zobrazí se zpráva **Používáte nejnovější verzi a momentálně nejsou k dispozici žádné nové aktualizace.** Když je dostupná aktualizace, lze ji z této záložky spustit.
+
+**Kanál aktualizací**
+    Umožňuje přepínat mezi podporovanými vydavatelskými kanály resolveru. Existují tři kanály:
+
+    .. list-table::
+       :header-rows: 1
+       :widths: 15 25 60
+
+       * - Kanál
+         - Stav
+         - Klíčové vlastnosti
+       * - **Verze 3**
+         - Aktuální kanál — hlavní podporovaná větev, průběžně přibývají nové funkce.
+         - **Vynucení bezpečného vyhledávání** (Google, YouTube, Bing, DuckDuckGo, Ecosia; kategorie: pro dospělé, zbraně, zneužívání dětí, drogy, terorismus, násilí). **Rate Limiting** (ochrana proti DDoS na UDP/53 — není dostupné pro DoH/DoT). **CPU-Aware Deferring** (zpomalí náročné klienty, když vytížení CPU vzroste). **Statické DNS záznamy** včetně SRV (A, AAAA, CNAME, TXT byly podporovány již dříve). Obsahuje všechny funkce verze 2.
+       * - **Verze 2**
+         - Pouze opravy — bezpečnostní a chybové opravy, žádné nové funkce.
+         - **Komplexní zpravodajství o hrozbách** (odstraňuje omezení velikosti databáze ve verzích 1.0.96 a starších). Volitelný modul **integrace s Active Directory** — obohacuje logy o názvy zařízení pomocí reverzního DNS vyhledávání.
+       * - **Verze 1**
+         - Konec životního cyklu — nevychází další opravy.
+         - Pro další bezpečnostní opravy přejděte na verzi 2.
+
+    Pro přechod mezi kanály klikněte na **Přepnout na tuto verzi** na kartě požadovaného kanálu.
+
+    .. note:: Některé funkce verze 3 (**Rate Limiting**, **CPU-Aware Deferring**, **Statické DNS záznamy**) se konfigurují přes YAML soubor pracovníky technické podpory Whalebone a nejsou v Admin Portálu dostupné přes UI.
+
+**Vrácení změn**
+    Pokud nedávná aktualizace nepřinesla očekávaný výsledek, lze v této záložce znovu aplikovat předchozí verzi. Pokud pro resolver není zaznamenána žádná předchozí verze, zobrazí se zpráva **Žádná předchozí verze není k dispozici**.
 
 .. image:: ./img/rollback.png
    :align: center
+
+.. _protokol-akci:
+
+Protokol akcí
+~~~~~~~~~~~~~
+
+Chronologický záznam všech akcí provedených na tomto resolveru — vytvoření, nasazení konfigurace, aktualizace, návraty atd. Každý záznam obsahuje časové razítko, typ akce a výsledek (například *Akce byla úspěšně dokončena*). Tento pohled využijete při ladění neúspěšných nasazení nebo pro potvrzení, kdy se změna skutečně dostala k resolveru.
+
+.. _integrace:
+
+Integrace
+~~~~~~~~~
+
+Pohled **Integrace** sdružuje volitelné funkce, které obohacují chování resolveru o data z vašeho prostředí. V současnosti je k dispozici jedna integrace.
+
+Vyhledávání názvů zařízení
+""""""""""""""""""""""""""
+
+Obohacuje DNS logy o názvy zařízení získané z PTR záznamů na vašich autoritativních DNS serverech. Konceptuální přehled najdete v sekci :doc:`active_directory`.
+
+.. note:: Tato funkce vyžaduje nejnovější verzi resolveru. Pokud je nainstalovaná verze starší, zobrazí portál upozornění s odkazem **Aktualizovat verzi resolveru**.
+
+.. important:: Veškeré změny nastavení integrací vyžadují nahrání politik na resolver ze stránky **Resolvery**.
+
+K dispozici jsou následující pole:
+
+* **Logovat názvy zařízení v síťovém provozu** — hlavní přepínač zapnutí/vypnutí integrace.
+* **Segmentace sítě** — zvolte, zda má resolver používat jediný seznam autoritativních DNS serverů (**Ne**), nebo používat autoritativní DNS servery podle jednotlivých síťových segmentů konfigurovaných v sekci :doc:`dns_resolution` (**Ano**).
+* **Autoritativní DNS servery** — seznam IP adres (a volitelné **Pokročilé nastavení**) používaných pro reverzní (PTR) vyhledávání při volbě segmentace sítě **Ne**.
+* **Časový limit reverzního DNS dotazu** — časový limit jednoho dotazu v milisekundách (výchozí ``500``).
+* **Počáteční kapacita úspěšné keše** — počet záznamů předem vyhrazených v keši úspěšných odpovědí (výchozí ``1000``).
+* **Maximální kapacita úspěšné keše** — maximální počet záznamů v keši úspěšných odpovědí (výchozí ``10000``).
+* **TTL úspěšné keše** — minimální alternativní TTL keše pro úspěšné PTR odpovědi v minutách (výchozí ``10``).
+* **Počáteční kapacita keše neúspěchů** — počet záznamů předem vyhrazených v keši neúspěšných odpovědí (výchozí ``1000``).
+* **Maximální kapacita keše neúspěchů** — maximální počet záznamů v keši neúspěšných odpovědí; při zaplnění se náhodná položka vyřadí (výchozí ``10000``).
+* **TTL keše neúspěchů** — počet minut, po které jsou neúspěšné PTR dotazy uchovávány před opětovným pokusem (výchozí ``10``).
+
+Kliknutím na **Uložit** uložíte změny.

--- a/cs/resolvers.rst
+++ b/cs/resolvers.rst
@@ -6,7 +6,7 @@ V záložce **Resolvery** je přehled vytvořených resolverů. Správce může 
 Přehled resolverů
 -----------------
 
-V hlavním přehledu resolverů jsou dlaždice s podrobnostmi o resolveru. Každá dlaždice obsahuje název resolveru a jeho ID, název hostitele, používanou verzi, jednu či více IP adres, indikátor stavu operačního systému a aktuální využití zdrojů (CPU, RAM a HDD). Stav komunikačního kanálu mezi resolverem a cloudem je označen barevnou tečkou vedle popisku **Stav**.
+Na stránce **Lokální resolvery pod vaší správou** jsou dlaždice s podrobnostmi o jednotlivých resolverech. Každá dlaždice obsahuje název resolveru a jeho ID, **Hostname**, **Verzi**, jednu či více IP adres, indikátor **Stav:** s barevnou tečkou a aktuální využití zdrojů (**CPU**, **RAM** a **HDD**). Pod dlaždicí je časová značka **Aktualizováno před {N} sekundami**.
 
 Resolver se může nacházet v jednom z těchto stavů:
 
@@ -16,26 +16,27 @@ Resolver se může nacházet v jednom z těchto stavů:
 * **Upgrading**: Resolveru byl vydán příkaz k aktualizaci. Tento stav by neměl přetrvávat déle než několik minut.
 * **Není nainstalován**: Resolver ještě nebyl nainstalován.
 
-Nad dlaždicemi resolverů jsou čtyři grafové záložky agregující metriky napříč všemi lokálními resolvery:
+Nad dlaždicemi resolverů je pět grafových záložek agregujících metriky napříč všemi lokálními resolvery:
 
 * **Časy odezvy** — rozdělení latence DNS dotazů do skupin (1 ms / 10 ms / 50 ms / 100 ms / 250 ms / 500 ms / 1000 ms / 1500 ms / pomalé).
-* **Provoz** — absolutní objem dotazů v čase.
-* **Provoz %** — relativní podíl na resolver.
-* **Denní požadavky** — celkový denní počet požadavků.
+* **Celkový provoz** — absolutní objem dotazů v čase.
+* **Celkový provoz %** — relativní podíl na resolver.
+* **Denní provoz** — celkový denní počet požadavků.
+* **Měsíční medián počtu dotazů** — měsíční mediánové hodnoty pro plánování kapacity.
 
-.. note:: Pokud zatím nemáte žádný nainstalovaný resolver, na stránce se zobrazí výzva **Vytvořte si první resolver** s tlačítkem **Vytvořit nový**. Postup instalace najdete v sekci :doc:`local_resolver`.
+.. note:: Pokud zatím nemáte žádný nainstalovaný resolver, na stránce se zobrazí výzva **Vytvořit nový**. Postup instalace najdete v sekci :doc:`local_resolver`.
 
 Akce nad resolverem
 ~~~~~~~~~~~~~~~~~~~
 
-Každá dlaždice resolveru má v pravém horním rohu nabídku se třemi tečkami obsahující následující akce:
+Každá dlaždice resolveru má v pravém horním rohu nabídku se třemi tečkami (tooltip **Další akce**) obsahující následující akce:
 
 * **Upravit resolver** — otevře detail resolveru (lze také kliknout na název resolveru).
-* **Vymazat keš pro doménu** — vyprázdní záznamy keše resolveru pro zadanou doménu.
-* **Vymazat keš resolveru** — vyprázdní celou DNS keš na resolveru.
-* **Trasovat doménu** — spustí trasování překladu domény z tohoto resolveru.
-* **Je tato doména blokována?** — ověří, zda by zadaná doména byla blokována stávající politikou.
-* **Změnit název** — přejmenuje resolver v portálu.
+* **Vyčistit cache pro doménu** — vyprázdní záznamy keše resolveru pro zadanou doménu.
+* **Vyčistit cache resolveru** — vyprázdní celou DNS keš na resolveru.
+* **Trace domény** — spustí trasování překladu domény z tohoto resolveru.
+* **Je doména blokovaná?** — ověří, zda by zadaná doména byla blokována stávající politikou.
+* **Změnit jméno** — přejmenuje resolver v portálu.
 * **Smazat resolver** — odstraní resolver z portálu. Tato akce neodinstaluje software na hostiteli; viz :doc:`uninstalling`.
 
 Nahrání konfigurace
@@ -53,16 +54,16 @@ Na následující animaci uvidíte nahrání konfigurace na resolver.
 Detail resolveru
 ----------------
 
-Kliknutím na název resolveru (nebo na **Upravit resolver** v nabídce na dlaždici) se otevře stránka s detailem resolveru. Stránka je rozdělena do šesti sekcí v levém menu:
+Kliknutím na název resolveru (nebo na **Upravit resolver** v nabídce na dlaždici) se otevře detail resolveru s nadpisem **Lokální resolver {jméno}**. V pravém horním rohu je tlačítko **Zpět na resolvery**. V levém menu je šest sekcí:
 
 * :ref:`statistiky`
 * :ref:`prirazeni-politik`
-* :ref:`pokrocila-konfigurace`
+* :ref:`nastaveni-dns-prekladu`
 * :ref:`aktualizace`
-* :ref:`protokol-akci`
+* :ref:`log-akci`
 * :ref:`integrace`
 
-Pravý sloupec zobrazuje **Název hostitele**, **Rozhraní** s přiřazenými IP adresami, **Platformu** (operační systém) a **Verzi** pro referenci.
+Pravý sloupec zobrazuje **Hostname**, **Rozhraní** s přiřazenými IP adresami, **Platformu** (operační systém) a **Verzi**.
 
 .. _statistiky:
 
@@ -71,14 +72,14 @@ Statistiky
 
 Výchozí pohled při otevření detailu resolveru. Obsahuje živé provozní grafy:
 
-* **Časy odezvy resolveru** — dotazy rozdělené podle latence (1 ms / 10 ms / 50 ms / 100 ms / 250 ms / 500 ms / 1000 ms / 1500 ms / pomalé).
-* **Zdraví** — procento úspěšných kontrol zdraví v rámci pozorovaného intervalu.
-* **Vytížení CPU** — využití procesoru na hostiteli resolveru.
-* **Využití paměti / Swap / Disku** — metriky paměťové zátěže.
-* **Počet zápisů / čtení** — diskové vstupně-výstupní operace.
-* **Zapsané / přečtené bajty** — propustnost diskového I/O.
-* **Přijaté / odeslané pakety** — počítadla síťových paketů.
-* **Přijaté / odeslané bajty** — síťová propustnost.
+* **Doby odezvy resolveru** — dotazy rozdělené podle latence (1 ms / 10 ms / 50 ms / 100 ms / 250 ms / 500 ms / 1000 ms / 1500 ms / pomalé).
+* **Health OK / Health fail** — procento úspěšných kontrol zdraví v rámci pozorovaného intervalu.
+* **Zatížení CPU** — využití procesoru na hostiteli resolveru.
+* **Využití RAM / Využití swapu / Zaplnění disku** — metriky paměťové zátěže.
+* **Počet zápisů / Počet čtení** — diskové vstupně-výstupní operace.
+* **Zapsáno Bytů / Přečteno Bytů** — propustnost diskového I/O.
+* **Paketů přijato / Paketů odesláno** — počítadla síťových paketů.
+* **Bytů přijato / Bytů odesláno** — síťová propustnost.
 
 .. _prirazeni-politik:
 
@@ -90,29 +91,29 @@ Pohled **Přiřazení politik** sdružuje tři související nastavení.
 Nastavení blokační stránky
 """"""""""""""""""""""""""
 
-* **Umístění blokační stránky** — výběr mezi **Whalebone Cloud** (blokační stránky obsluhované Whalebone) a **On-premise lokální resolver** (blokační stránky obsluhované z hostitele resolveru). Při volbě **On-premise lokální resolver** se zobrazí dvě další pole:
+* **Umístění blokační stránky** — výběr mezi **Whalebone Cloud** (blokační stránky obsluhované Whalebone) a **Lokální na resolveru** (blokační stránky obsluhované z hostitele resolveru). Při volbě **Lokální na resolveru** se zobrazí dvě další pole:
 
   * **IPv4 pro blokační stránku** — IPv4 adresa pro blokační stránku. Měla by být nastavena na veřejnou IP adresu resolveru.
   * **IPv6 pro blokační stránku** — IPv6 adresa pro blokační stránku. Měla by být nastavena na veřejnou IP adresu resolveru.
 
 .. tip:: Blokační stránky jsou umístěny **přímo** na resolverech, takže je třeba použít IP adresy, které jsou inzerovány klientům. Klienti pak budou při blokování přesměrováni na IP adresu resolveru. Zajistěte, aby byly na firewallu přístupné porty 80 a 443.
 
-Strategie přiřazování politik
-"""""""""""""""""""""""""""""
+Párování politik
+""""""""""""""""
 
-Volba **Přiřadit politiku podle IP** určuje, podle čeho resolver rozhoduje, jakou politiku aplikovat na DNS dotaz:
+Volba **Vybrat politiku podle IP** určuje, podle čeho resolver rozhoduje, jakou politiku aplikovat na DNS dotaz:
 
-* **Klient** — přiřazení podle IP adresy klienta. Použijte, pokud chcete politiky řízené IP rozsahy klientských zařízení (například odlišné politiky pro různé podsítě koncových uživatelů).
-* **Resolver** — přiřazení podle IP adresy resolveru. Použijte, pokud se klienti dostávají k Whalebone prostřednictvím vlastního DNS serveru a politika má být určena podle IP tohoto serveru.
+* **Klienta** — přiřazení podle IP adresy klienta. Použijte, pokud chcete politiky řízené IP rozsahy klientských zařízení (například odlišné politiky pro různé podsítě koncových uživatelů).
+* **Resolveru** — přiřazení podle IP adresy resolveru. Použijte, pokud se klienti dostávají k Whalebone prostřednictvím vlastního DNS serveru a politika má být určena podle IP tohoto serveru.
 
 Tabulka přiřazení politik
 """""""""""""""""""""""""
 
-Zásady zabezpečení a obsahu lze granulárním způsobem přiřadit různým segmentům sítě. Nastavení se vztahuje na jednotlivé resolvery a lze je nakonfigurovat v části **Resolvery** → ``Název resolveru`` → **Přiřazení politik**.
+Zásady zabezpečení a obsahu lze granulárním způsobem přiřadit různým segmentům sítě. Tabulka **Přiřazení politik** má sloupce **Rozsah**, **Politika** a **Možnosti**. Výchozí řádek **Tato politika platí pro všechny nedefinované rozsahy** je vždy přítomen a používá **Výchozí politiku**. Nastavení se vztahuje na jednotlivé resolvery a lze je nakonfigurovat v části **Resolvery** → ``Název resolveru`` → **Přiřazení politik**.
 
 .. note:: Konfigurace se vztahuje **na každý resolver zvlášť**. V případě, že chcete konfiguraci použít pro více resolverů, upravte konfiguraci u všech resolverů.
 
-Politiky lze aplikovat přidáním rozsahů IP ve vstupních polích:
+Politiky lze aplikovat přidáním rozsahů IP. Nový řádek přidáte tlačítkem **+ Přidat rozsah**:
 
 .. image:: ./img/add-policy.PNG
    :align: center
@@ -160,7 +161,7 @@ Následující obrázek ukazuje proces přiřazování politik k rozsahům:
 .. image:: ./img/policy_task.png
    :align: center
 
-.. note:: Po přidání politik k rozsahům je nutné kliknout na **Uložit do resolveru**, aby se změny projevily. Poté budou změny ověřeny a vyskakovací zpráva poskytne další informace.
+.. note:: Po přidání politik k rozsahům je nutné kliknout na **Uložit k resolveru**, aby se změny projevily. Poté budou změny ověřeny a vyskakovací zpráva poskytne další informace.
 
 Pro přidání dalších položek ke stávajícímu přiřazení lze přidat nový rozsah sítě pomocí **nového řádku** jako oddělovače.
 
@@ -181,21 +182,21 @@ Pro každý přidaný rozsah IP adres je v rozevírací nabídce uvedena přiřa
 
 .. note:: Po provedení potřebných změn v nastavení blokační stránky zkontrolujte, zda je třeba nové nastavení nahrát na resolvery.
 
-.. _pokrocila-konfigurace:
+.. _nastaveni-dns-prekladu:
 
-Pokročilá konfigurace
-~~~~~~~~~~~~~~~~~~~~~
+Nastavení DNS překladu
+~~~~~~~~~~~~~~~~~~~~~~
 
-Pohled **Pokročilá konfigurace** zpřístupňuje technická nastavení na úrovni resolveru.
+Pohled **Nastavení DNS překladu** (v anglické verzi portálu *Advanced configuration*) zpřístupňuje technická nastavení na úrovni resolveru.
 
-* **Volba konfigurace DNS překladu** — vyberte profil DNS překladu, který se má použít na tento resolver. Profily se definují v sekci :doc:`dns_resolution`. Výchozím profilem je **Default DNS resolution**.
+* **Vyberte konfiguraci DNS překladu** — vyberte profil DNS překladu, který se má použít na tento resolver. Profily se definují v sekci :doc:`dns_resolution`. Výchozím profilem je **Výchozí DNS překlad**.
 
 V sekci **Expertní nastavení** (ve výchozím stavu sbalená) lze přepsat následující výchozí hodnoty:
 
 * **Vypnout logování DNS** — když je zapnuto, resolver nezaznamenává lokální záznamy dotazů. Používejte pouze pokud to vyžaduje objem logů nebo požadavky na soukromí; mnoho funkcí (Hrozby, Obsah) na těchto záznamech závisí.
-* **Upravit velikost rotace logů** — přepíše výchozí velikost pro rotaci log souborů resolveru.
-* **Cíle syslogu** — přidá jeden či více vzdálených syslog cílů, na které bude resolver přeposílat logy. Dostupné log soubory a formáty popisuje sekce :doc:`syslog_integration`.
-* **Počet procesů resolveru** — přepíše počet pracovních procesů pro překlad na hostiteli.
+* **Upravit velikost, při které se rotují logy** — přepíše výchozí velikost pro rotaci log souborů resolveru.
+* **Syslog** — tlačítkem **+ Přidat** (tooltip *Přidat syslog*) přidá jeden či více vzdálených syslog cílů, na které bude resolver přeposílat logy. Dostupné log soubory a formáty popisuje sekce :doc:`syslog_integration`.
+* **Počet procesů Resolveru** — přepíše počet pracovních procesů pro překlad na hostiteli.
 * **Naslouchat na všech IP adresách** — je-li zapnuto (výchozí), resolver naslouchá na všech IP adresách všech rozhraní hostitele. Vypněte pro omezení naslouchání pouze na vybranou podmnožinu (konfiguruje se přes Whalebone podporu).
 
 Kliknutím na **Uložit** uložíte změny. Stejně jako u jiných změn konfigurace je vyžadováno nasazení na resolver.
@@ -205,12 +206,12 @@ Kliknutím na **Uložit** uložíte změny. Stejně jako u jiných změn konfigu
 Aktualizace
 ~~~~~~~~~~~
 
-Pohled **Aktualizace** zobrazuje aktuální verzi resolveru a datum vydání a je rozdělen do tří podzáložek.
+Pohled **Aktualizace** zobrazuje aktuální verzi resolveru a datum vydání ve tvaru *Současná verze: {n}  Vydáno: {datum}* a je rozdělen do tří podzáložek.
 
-**Dostupná aktualizace**
-    Ukazuje, zda je dostupná novější verze v aktuálním kanálu. Pokud je resolver aktuální, zobrazí se zpráva **Používáte nejnovější verzi a momentálně nejsou k dispozici žádné nové aktualizace.** Když je dostupná aktualizace, lze ji z této záložky spustit.
+**Dostupné aktualizace**
+    Ukazuje, zda je dostupná novější verze v aktuálním kanálu. Pokud je resolver aktuální, zobrazí se zpráva **Používáte nejnovější verzi a zatím nejsou k dispozici žádné nové aktualizace.** Když je dostupná aktualizace, lze ji z této záložky spustit.
 
-**Kanál aktualizací**
+**Upgradovat verzi**
     Umožňuje přepínat mezi podporovanými vydavatelskými kanály resolveru. Existují tři kanály:
 
     .. list-table::
@@ -221,59 +222,62 @@ Pohled **Aktualizace** zobrazuje aktuální verzi resolveru a datum vydání a j
          - Stav
          - Klíčové vlastnosti
        * - **Verze 3**
-         - Aktuální kanál — hlavní podporovaná větev, průběžně přibývají nové funkce.
-         - **Vynucení bezpečného vyhledávání** (Google, YouTube, Bing, DuckDuckGo, Ecosia; kategorie: pro dospělé, zbraně, zneužívání dětí, drogy, terorismus, násilí). **Rate Limiting** (ochrana proti DDoS na UDP/53 — není dostupné pro DoH/DoT). **CPU-Aware Deferring** (zpomalí náročné klienty, když vytížení CPU vzroste). **Statické DNS záznamy** včetně SRV (A, AAAA, CNAME, TXT byly podporovány již dříve). Obsahuje všechny funkce verze 2.
+         - **Aktuální kanál** — hlavní podporovaná verze, nové funkce jsou průběžně přidávány.
+         - **SafeSearch** — když je zapnuta filtrace některé z kategorií *Pro dospělé*, *Zbraně*, *Zneužívání dětí*, *Drogy*, *Terorismus* nebo *Násilí*, resolver odpovídá na dotazy Google, YouTube, Bing, DuckDuckGo a Ecosia pomocí IP/CNAME adres SafeSearch a zobrazí se tak pouze bezpečné a filtrované výsledky. **Ochrana proti DDoS** — konfigurovatelné omezení rychlosti (rate-limiting), které blokuje DNS-amplification útoky na UDP/53 a brání jednomu klientovi v zahlcení resolveru. Nadbytečné dotazy jsou zahozeny a legitimní dotazy jsou nadále odbaveny v maximální rychlosti. (Nedostupné pro DoH/DoT.) Při vysokém vytížení CPU automaticky zpomaluje náročné klienty a tím chrání celkový výkon resolveru. **Statické DNS záznamy** — ve verzi 3 přibyla podpora záznamů SRV; záznamy A, AAAA, CNAME, TXT byly podporovány již dříve. Zahrnuje všechny funkce verze 2.
        * - **Verze 2**
-         - Pouze opravy — bezpečnostní a chybové opravy, žádné nové funkce.
-         - **Komplexní zpravodajství o hrozbách** (odstraňuje omezení velikosti databáze ve verzích 1.0.96 a starších). Volitelný modul **integrace s Active Directory** — obohacuje logy o názvy zařízení pomocí reverzního DNS vyhledávání.
+         - Průběžné bezpečnostní záplaty a opravy chyb; žádné nové funkce.
+         - **Komplexní informace o hrozbách**: verze 1.0.96 a starší narazily na omezení kvůli velikosti databáze. Aktualizace umožňuje přístup ke kompletním aktualizacím o nově vznikajících hrozbách a škodlivých doménách. **Integrace s Active Directory**: obohacuje protokoly o názvy hostitelů zařízení prostřednictvím zpětného vyhledávání DNS (*volitelný modul*).
        * - **Verze 1**
-         - Konec životního cyklu — nevychází další opravy.
-         - Pro další bezpečnostní opravy přejděte na verzi 2.
+         - Tato větev již nedostává záplaty ani podporu.
+         - Upgradujte na verzi 2, abyste i nadále dostávali bezpečnostní záplaty, nebo přejděte na verzi 3, abyste měli k dispozici nejnovější funkce.
 
     Pro přechod mezi kanály klikněte na **Přepnout na tuto verzi** na kartě požadovaného kanálu.
 
-    .. note:: Některé funkce verze 3 (**Rate Limiting**, **CPU-Aware Deferring**, **Statické DNS záznamy**) se konfigurují přes YAML soubor pracovníky technické podpory Whalebone a nejsou v Admin Portálu dostupné přes UI.
+    .. note:: Funkce **Ochrana proti DDoS** a **Statické DNS záznamy** se nastavují v souboru YAML naším týmem technických konzultantů. Pro konfiguraci těchto funkcí je vám tým k dispozici na support@whalebone.io.
 
 **Vrácení změn**
-    Pokud nedávná aktualizace nepřinesla očekávaný výsledek, lze v této záložce znovu aplikovat předchozí verzi. Pokud pro resolver není zaznamenána žádná předchozí verze, zobrazí se zpráva **Žádná předchozí verze není k dispozici**.
+    Pokud nedávná aktualizace nepřinesla očekávaný výsledek, lze v této záložce znovu aplikovat předchozí verzi. Pokud pro resolver není zaznamenána žádná předchozí verze, zobrazí se zpráva **Žádná verze k dispozici**.
 
 .. image:: ./img/rollback.png
    :align: center
 
-.. _protokol-akci:
+.. _log-akci:
 
-Protokol akcí
-~~~~~~~~~~~~~
+Log akcí
+~~~~~~~~
 
-Chronologický záznam všech akcí provedených na tomto resolveru — vytvoření, nasazení konfigurace, aktualizace, návraty atd. Každý záznam obsahuje časové razítko, typ akce a výsledek (například *Akce byla úspěšně dokončena*). Tento pohled využijete při ladění neúspěšných nasazení nebo pro potvrzení, kdy se změna skutečně dostala k resolveru.
+Chronologický záznam všech akcí provedených na tomto resolveru — vytvoření, nasazení konfigurace, aktualizace, návraty atd. Každý záznam obsahuje časové razítko (např. *2026.05.15 13:53:54* a pod ním relativní *pár sekund*), typ akce (např. ``Create``) a výsledek (např. *Akce úspěšně skončila*). Tento pohled využijete při ladění neúspěšných nasazení nebo pro potvrzení, kdy se změna skutečně dostala k resolveru.
 
 .. _integrace:
 
 Integrace
 ~~~~~~~~~
 
-Pohled **Integrace** sdružuje volitelné funkce, které obohacují chování resolveru o data z vašeho prostředí. V současnosti je k dispozici jedna integrace.
+Pohled **Integrace** sdružuje volitelné funkce, které obohacují chování resolveru o data z vašeho prostředí. V současnosti je k dispozici jedna integrace na záložce **Vyhledání názvu zařízení**.
 
-Vyhledávání názvů zařízení
-""""""""""""""""""""""""""
+Vyhledání názvu zařízení
+""""""""""""""""""""""""
 
 Obohacuje DNS logy o názvy zařízení získané z PTR záznamů na vašich autoritativních DNS serverech. Konceptuální přehled najdete v sekci :doc:`active_directory`.
 
-.. note:: Tato funkce vyžaduje nejnovější verzi resolveru. Pokud je nainstalovaná verze starší, zobrazí portál upozornění s odkazem **Aktualizovat verzi resolveru**.
+.. note:: Tato funkce vyžaduje nejnovější verzi resolveru. Pokud je nainstalovaná verze starší, zobrazí portál upozornění s odkazem na aktualizaci.
 
 .. important:: Veškeré změny nastavení integrací vyžadují nahrání politik na resolver ze stránky **Resolvery**.
 
 K dispozici jsou následující pole:
 
-* **Logovat názvy zařízení v síťovém provozu** — hlavní přepínač zapnutí/vypnutí integrace.
-* **Segmentace sítě** — zvolte, zda má resolver používat jediný seznam autoritativních DNS serverů (**Ne**), nebo používat autoritativní DNS servery podle jednotlivých síťových segmentů konfigurovaných v sekci :doc:`dns_resolution` (**Ano**).
-* **Autoritativní DNS servery** — seznam IP adres (a volitelné **Pokročilé nastavení**) používaných pro reverzní (PTR) vyhledávání při volbě segmentace sítě **Ne**.
-* **Časový limit reverzního DNS dotazu** — časový limit jednoho dotazu v milisekundách (výchozí ``500``).
-* **Počáteční kapacita úspěšné keše** — počet záznamů předem vyhrazených v keši úspěšných odpovědí (výchozí ``1000``).
-* **Maximální kapacita úspěšné keše** — maximální počet záznamů v keši úspěšných odpovědí (výchozí ``10000``).
-* **TTL úspěšné keše** — minimální alternativní TTL keše pro úspěšné PTR odpovědi v minutách (výchozí ``10``).
-* **Počáteční kapacita keše neúspěchů** — počet záznamů předem vyhrazených v keši neúspěšných odpovědí (výchozí ``1000``).
-* **Maximální kapacita keše neúspěchů** — maximální počet záznamů v keši neúspěšných odpovědí; při zaplnění se náhodná položka vyřadí (výchozí ``10000``).
-* **TTL keše neúspěchů** — počet minut, po které jsou neúspěšné PTR dotazy uchovávány před opětovným pokusem (výchozí ``10``).
+* **Zaznamenat názvy zařízení do síťového provozu** — hlavní přepínač zapnutí/vypnutí integrace. Nápověda: *"Povolte vyhledávání názvů zařízení pomocí záznamů PTR na vašich místních autoritativních jmenných serverech."*
+* **Segmentace sítě** — zvolte, zda má resolver používat jediný seznam autoritativních DNS serverů (**Ne** — *"použijte autoritativní jmenný server(y) uvedený níže pro vyhledávání názvu zařízení"*), nebo používat autoritativní DNS servery podle jednotlivých síťových segmentů konfigurovaných v sekci :doc:`dns_resolution` (**Ano** — *"použijte autoritativní jmenné servery podle nastavení Překlad DNS"*).
+* **Autoritativní jmenné servery** — seznam IP adres používaných pro reverzní (PTR) vyhledávání při volbě **Segmentace sítě: Ne**. Další jmenné servery se používají, pokud vyprší časový limit požadavků na předchozí.
+
+V sekci **Pokročilé nastavení** (rozbalovací) jsou dostupná tato pole:
+
+* **Časový limit reverzního dotazu DNS** — časový limit jednoho dotazu v milisekundách (výchozí ``500``).
+* **Úspěch Počáteční kapacita mezipaměti** — počet položek, pro které je při inicializaci vyhrazena paměť v keši úspěšných odpovědí (výchozí ``1000``).
+* **Úspěch Kapacita mezipaměti max** — maximální počet položek v keši úspěšných odpovědí; doporučená hodnota je 110 % očekávaných zařízení v síti. Po dosažení této kapacity je náhodný předmět vyřazen. (výchozí ``10000``).
+* **Úspěch Kapacita mezipaměti TTL** — minimální alternativní TTL keše pro úspěšné PTR odpovědi, v minutách (výchozí ``10``).
+* **Selhání Počáteční kapacita mezipaměti** — počet položek, pro které je při inicializaci vyhrazena paměť v keši neúspěšných odpovědí (výchozí ``1000``).
+* **Porucha Kapacita mezipaměti max** — maximální počet položek v keši neúspěšných odpovědí; při zaplnění se náhodná položka vyřadí (výchozí ``10000``). *Pozn.: portál zde používá "Porucha", jinde "Selhání" — jde o nekonzistenci na straně portálu.*
+* **TTL mezipaměti selhání** — počet minut, po které jsou neúspěšné PTR dotazy uchovávány před opětovným pokusem (výchozí ``10``).
 
 Kliknutím na **Uložit** uložíte změny.

--- a/en/resolvers.rst
+++ b/en/resolvers.rst
@@ -1,12 +1,12 @@
 Resolver management
 ===================
 
-On the **Resolvers** page, there is an overview of the created resolvers. Administrators can adjust the configuration, deploy updates, and install new resolvers.
+On the **Resolvers** page, there is an overview of the created resolvers. Administrators can adjust the configuration, deploy updates, install new resolvers, and inspect detailed traffic and health metrics for each resolver.
 
 Resolvers overview
 ------------------
 
-In the main resolver overview, there are tiles with resolver details. The overview includes information about the operating system and resources, such as CPU, memory and HDD usage. There is also the status of the communication channel between the resolver and the cloud, indicated by the color-coded dot.
+In the main resolver overview, there are tiles with resolver details. Each tile shows the resolver name and ID, the hostname, the running version, one or more IP addresses, the operating system status indicator, and the live resource usage (CPU, RAM and HDD). The status of the communication channel between the resolver and the cloud is indicated by a color-coded dot next to the **Status** label.
 
 The resolver can be in one of these states:
 
@@ -15,6 +15,28 @@ The resolver can be in one of these states:
 * **Unavailable**: The resolver has lost connection with Whalebone Cloud. This state does not affect the DNS translation; however, the resolver cannot get threat database updates and might not respond to policy or configuration changes initiated from the portal.
 * **Upgrading**: An upgrade command has been issued to the resolver. This state should not persist for more than a few minutes.
 * **Not installed**: The resolver was not yet installed.
+
+Above the resolver cards, four chart tabs aggregate metrics across all your local resolvers:
+
+* **Response times** — distribution of DNS query latencies by bucket (1 ms / 10 ms / 50 ms / 100 ms / 250 ms / 500 ms / 1000 ms / 1500 ms / slow).
+* **Traffic** — absolute query volume over time.
+* **Traffic %** — relative share per resolver.
+* **Daily requests** — total daily request counts.
+
+.. note:: If you have not yet installed a resolver, the page shows a **Create your first resolver** empty state with a **Create new** button. See :doc:`local_resolver` for installation steps.
+
+Per-resolver actions
+~~~~~~~~~~~~~~~~~~~~
+
+Each resolver tile has a three-dot menu in the top-right corner with the following actions:
+
+* **Edit resolver** — open the resolver detail page (also opened by clicking the resolver name).
+* **Clear cache for domain** — flush the resolver cache entries for a single domain you specify.
+* **Clear resolver cache** — flush the entire DNS cache on the resolver.
+* **Trace domain** — run a domain resolution trace from this resolver.
+* **Is this domain blocked?** — check whether a given domain would be blocked by the current policy.
+* **Change name** — rename the resolver in the portal.
+* **Delete resolver** — remove the resolver from the portal. This does not uninstall the software on the host; see :doc:`uninstalling`.
 
 Deploy configuration
 --------------------
@@ -28,18 +50,69 @@ The following animation demonstrates a configuration deployment to a resolver.
 .. image:: ./img/lrv2-deployconfig.gif
    :align: center
 
-Configure Policy per Network Segment
-------------------------------------
+Resolver detail
+---------------
 
-Security and content polices can be assigned in a granular manner to different segments of the network.
+Clicking the name of a resolver (or **Edit resolver** in the per-card menu) opens the resolver detail page. The page has six sub-sections, listed in the left sidebar:
 
-The setting applies per resolver and can be configured under **Resolvers** → ``Name of the resolver`` → **Policy Assignment**.
+* :ref:`statistics`
+* :ref:`policy-assignment`
+* :ref:`advanced-configuration`
+* :ref:`upgrade`
+* :ref:`actions-log`
+* :ref:`integrations`
 
-.. note:: The configuration is **per resolver**. In case you want to apply the configuration to more than one resolver, please modify all the necessary resolvers.
+The right-hand column shows the resolver's **Hostname**, **Interface(s)** with assigned IP addresses, **Platform** (operating system), and **Version** for reference.
 
-The policies can be applied by adding IP ranges in the available input form:
+.. _statistics:
 
-Policy assignment.
+Statistics
+~~~~~~~~~~
+
+The default landing view for a resolver. Provides live operational charts:
+
+* **Resolver response times** — queries grouped into latency buckets (1 ms / 10 ms / 50 ms / 100 ms / 250 ms / 500 ms / 1000 ms / 1500 ms / slow).
+* **Health** — percentage of successful health checks over the observed interval.
+* **CPU load** — CPU usage on the resolver host.
+* **Memory usage / Swap usage / Disk usage** — memory pressure metrics.
+* **Write count / Read count** — disk I/O operations.
+* **Write bytes / Read bytes** — disk I/O throughput.
+* **Packets received / Packets sent** — network packet counters.
+* **Bytes received / Bytes sent** — network throughput.
+
+.. _policy-assignment:
+
+Policy assignment
+~~~~~~~~~~~~~~~~~
+
+The Policy assignment view groups three related settings.
+
+Blocking page settings
+""""""""""""""""""""""
+
+* **Blocking page location** — choose between **Whalebone Cloud** (blocking pages served by Whalebone) and **On-premise local resolver** (blocking pages served from the resolver host). When **On-premise local resolver** is selected, two additional fields appear:
+
+  * **IPv4 for Blocking page** — IPv4 address used for the blocking page. Should be set to the public IP of the resolver.
+  * **IPv6 for Blocking page** — IPv6 address used for the blocking page. Should be set to the public IP of the resolver.
+
+.. tip:: The Blocking Pages are hosted **directly** on the Resolvers, so the IP addresses that are advertised to the clients must be used. The clients will then be redirected to the IP address of the resolver upon blocking. Please ensure that ports 80 and 443 are accessible on the firewall.
+
+Policy matching strategy
+""""""""""""""""""""""""
+
+The **Match policy based on IP of** option controls how the resolver decides which policy to apply to a DNS query:
+
+* **Client** — match based on the IP of the client. Use this when you want policies driven by client-side IP ranges (for example, different policies per subnet of end-user devices).
+* **Resolver** — match based on the IP of the resolver. Use this when the clients reach Whalebone through their own DNS server and you want the policy decided by that server's IP.
+
+Policy assignment table
+"""""""""""""""""""""""
+
+Security and content policies can be assigned in a granular manner to different segments of the network. The setting applies per resolver and is configured under **Resolvers** → ``Name of the resolver`` → **Policy assignment**.
+
+.. note:: The configuration is **per resolver**. To apply the same configuration to more than one resolver, repeat the setup on each.
+
+Policies are applied by adding IP ranges in the available input form:
 
 .. image:: ./img/add-policy.PNG
    :align: center
@@ -48,11 +121,9 @@ In order to provide a better understanding, let's consider an example with the n
 
 We have created 3 different policies:
 
-* **Default**: the policy that we want to apply to the whole network; this is the most generic policy
+* **Default**: the policy that we want to apply to the whole network; this is the most generic policy.
 * **Exception**: a policy that must be applied to a specific segment in the network, which will have all security and content filtering disabled.
 * **Schools**: a policy that we want to apply to 2 different subnets that have been assigned to school environments. In this case, we have chosen to be more strict in the blocking.
-
-Example policy settings.
 
 .. figure:: ./img/policies-example-1.png
    :alt: Default policy
@@ -89,23 +160,14 @@ The following image shows the process of assigning the policies:
 .. image:: ./img/policy_task.png
    :align: center
 
-.. note::  After adding the networks, you must click on **Save to Resolver** in order to take effect. The changes will then be validated, and a pop-up message will provide additional information.
+.. note:: After adding the networks, you must click on **Save to resolver** in order to take effect. The changes will then be validated, and a pop-up message will provide additional information.
 
 In order to assign additional entries to an existing assignment, a new network range can be appended using a `newline` as a separator.
 
-Building on the previous example, in case we wanted to add the subnet ``10.10.30.0/24`` to the Exception Policy, we can simply add the subnet to the existing policy assignment:
+Building on the previous example, in case we wanted to add the subnet ``10.10.30.0/24`` to the Exception policy, we can simply add the subnet to the existing policy assignment:
 
 .. image:: ./img/add-range.gif
    :align: center
-
-Configure Blocking Pages
-------------------------
-
-In a similar manner to the Security Policies, the Blocking Pages can also be assigned to particular network ranges.
-
-The first step is to select the **On-premise local resolver** for the **Blocking Page Location** option. Two new fields are enabled where the IPv4 and IPv6 addresses of the Blocking Pages must be filled in.
-
-.. tip:: The Blocking Pages are being hosted **directly** on the Resolvers so the IP addresses that are advertised to the clients must be used. The clients will then be redirected to the IP address of the resolver upon blocking. Please ensure that ports 80 and 443 are accessible on the firewall.
 
 For each IP range that is added, there is a drop-down menu for the Blocking Page that should be assigned.
 
@@ -115,26 +177,103 @@ For each IP range that is added, there is a drop-down menu for the Blocking Page
 
    Assign Blocking Page to IP range
 
-.. important:: The first entry in the **Policy Assignment** is considered the Default/Fallback. In case a client accesses the resolver from an undefined IP range, the respective options will apply.
+.. important:: The first entry in the **Policy assignment** is considered the Default/Fallback. In case a client accesses the resolver from an undefined IP range, the respective options will apply.
 
 .. note:: After making the necessary changes to the Blocking Page settings, please check whether the resolvers need to be redeployed.
 
-Upgrade or Rollback a Resolver
-------------------------------
+.. _advanced-configuration:
 
-When a new version of the Resolver is released, a **blue box** with the text **There is an available upgrade for resolvers. You can find it under the "Upgrade available" link** that appears on the resolvers' overview page.
+Advanced configuration
+~~~~~~~~~~~~~~~~~~~~~~
 
-.. image:: ./img/upgrade.png
-   :align: center
+The Advanced configuration view exposes resolver-level technical settings.
 
-Upon clicking the **Upgrade available** link, you are redirected to a page that provides an overview of the new upgrade, its release notes, and a button that initializes the upgrade procedure.
+* **Choose DNS resolution configuration** — select a DNS resolution profile to apply to this resolver. Profiles are defined under :doc:`dns_resolution`. The default profile is **Default DNS resolution**.
 
-.. image:: ./img/upgrade-2.png
-   :align: center
+Under **Expert settings** (collapsed by default) you can override the following defaults:
 
-From this menu, the upgrade of the resolver can be initiated by clicking the **Upgrade resolver now** button.
+* **Disable DNS logging** — when enabled, the resolver does not record query logs locally. Use only when log volume or privacy requirements demand it; many features (Threats, Content) rely on these logs.
+* **Adjust log rotation size** — override the default rotation size for resolver log files.
+* **Syslog destinations** — add one or more remote syslog destinations the resolver will forward logs to. See :doc:`syslog_integration` for the available log files and formats.
+* **Resolver process count** — override the number of resolution worker processes on the host.
+* **Bind to all IPs** — when enabled (default), the resolver listens on every IP address of every interface configured on the host. Disable to restrict listening to a specific subset (configured via Whalebone support).
 
-In case the installation of the new version does not yield the expected outcome, a rollback to the previous version is possible anytime in the **Rollback** tab, which can be found in **Resolvers** → ``Name of the resolver`` → Upgrade:
+Click **Save** to persist changes. As with other configuration changes, deployment to the resolver is required.
+
+.. _upgrade:
+
+Upgrade
+~~~~~~~
+
+The Upgrade view shows the resolver's current version and release date and is split into three sub-tabs.
+
+**Available upgrade**
+    Shows whether a newer version is available for the current channel. If the resolver is up to date, the message **You're running the latest version and there are no new upgrades yet.** is displayed. When an upgrade is available, the upgrade procedure can be initiated from this tab.
+
+**Upgrade channel**
+    Lets you switch between the supported resolver release channels. Three channels exist:
+
+    .. list-table::
+       :header-rows: 1
+       :widths: 15 20 65
+
+       * - Channel
+         - Status
+         - Highlights
+       * - **Version 3**
+         - Current channel — main supported branch, new capabilities added continuously.
+         - **Safe Search Enforcement** (Google, YouTube, Bing, DuckDuckGo, Ecosia; categories: Adult, Weapons, Child Abuse, Drugs, Terrorism, Violence). **Rate Limiting** (DDoS protection on UDP/53 — not available for DoH/DoT). **CPU-Aware Deferring** (throttles heavy clients when CPU spikes). **Static DNS Records** including SRV (A, AAAA, CNAME, TXT were already supported). Includes all features from Version 2.
+       * - **Version 2**
+         - Patch-only — security and bug fixes, no new features.
+         - **Comprehensive Threat Intelligence** (lifts the database-size constraints of 1.0.96 and earlier). Optional **Active Directory integration** module — enriches logs with device hostnames via reverse DNS.
+       * - **Version 1**
+         - End of life — no further patches.
+         - Upgrade to Version 2 to keep receiving security patches.
+
+    To move between channels, click **Switch to this version** on the desired channel card.
+
+    .. note:: Several Version 3 features (**Rate Limiting**, **CPU-Aware Deferring**, **Static DNS Records**) are configured via a YAML file by Whalebone Technical Support and are not exposed in the Admin Portal UI.
+
+**Rollback**
+    If the most recent upgrade did not yield the expected outcome, the previous version can be re-applied here. When no previous version is recorded for the resolver, the tab shows **There is no previous version**.
 
 .. image:: ./img/rollback.png
    :align: center
+
+.. _actions-log:
+
+Actions log
+~~~~~~~~~~~
+
+A chronological audit trail of every action issued to this resolver — create, configuration deploys, upgrades, rollbacks, and so on. Each entry shows the timestamp, the action type, and the result (for example, *Action was completed successfully*). Use this view to debug failed deployments or to confirm when a change actually reached the resolver.
+
+.. _integrations:
+
+Integrations
+~~~~~~~~~~~~
+
+The Integrations view groups optional features that enrich the resolver's behavior with data from your environment. Currently, one integration is available.
+
+Device name lookup
+""""""""""""""""""
+
+Enriches DNS logs with device hostnames resolved from PTR records on your authoritative nameserver(s). See :doc:`active_directory` for the conceptual overview.
+
+.. note:: This feature requires the latest resolver version. The portal displays a banner with an **Upgrade Resolver version** link if the installed resolver is too old.
+
+.. important:: All changes to integration settings require deployment of policies to the resolver from the Resolvers list page.
+
+The following fields are available:
+
+* **Log device names in your network traffic** — master on/off toggle for the integration.
+* **Network segmentation** — choose whether the resolver should use a single authoritative nameserver list (**No**) or use authoritative nameservers per network segment as configured in :doc:`dns_resolution` (**Yes**).
+* **Authoritative nameservers** — list of IPs (and optional **Advanced setup**) used for reverse (PTR) lookups when network segmentation is **No**.
+* **Reverse DNS query timeout** — per-query timeout in milliseconds (default ``500``).
+* **Success Cache capacity initial** — number of entries the success cache is pre-allocated to hold (default ``1000``).
+* **Success Cache capacity max** — maximum number of entries the success cache can hold (default ``10000``).
+* **Success Cache capacity TTL** — minimum alternative cache TTL for successful PTR responses, in minutes (default ``10``).
+* **Failure Cache capacity initial** — number of entries the failure cache is pre-allocated to hold (default ``1000``).
+* **Failure Cache capacity max** — maximum number of entries the failure cache can hold; when full, a random item is evicted (default ``10000``).
+* **Failure Cache TTL** — minutes that failed PTR queries are remembered before being retried (default ``10``).
+
+Click **Save** to persist changes.


### PR DESCRIPTION
…nels, Advanced configuration, Integrations

Restructures en/resolvers.rst and cs/resolvers.rst to match the current Admin Portal UI for the Resolver management page. The previous version described a single-flow narrative that no longer matches the live portal's six-sub-tab detail page.

Added:
- Resolvers list chart tabs (Response times, Traffic, Traffic %, Daily requests)
- Per-resolver 3-dot actions menu (Clear cache, Trace domain, Is this domain blocked, Change name, Delete)
- Resolver detail page with six sub-tabs
- Statistics tab live charts
- Policy matching strategy (Client vs Resolver)
- Advanced configuration tab (DNS resolution profile + Expert settings)
- Upgrade channels (Version 1/2/3 lifecycle and feature matrix)
- Actions log tab
- Integrations / Device name lookup tab

Preserved all existing accurate content and image references verbatim.

Stale wording in the Upgrade section (blue box / 'Upgrade resolver now' button pattern) replaced with the current three-tab / three-channel description.

Both English and Czech kept in sync.