### PR TITLE
Add the DoH and DoT addresses to the Cloud resolvers section

### DIFF
--- a/cs/cloud_resolver.rst
+++ b/cs/cloud_resolver.rst
@@ -1,17 +1,12 @@
 Cloudové DNS resolvery
 ----------------------
 
-Videonávod krok za krokem si můžete prohlédnout :ref:`zde<Cloudove resolvery video>`.
-Whalebone Cloud DNS resolver je služba určená především pro malé nebo střední zákazníky, kteří mohou cloudové resolvery používat jako záložní resolver. Typicky je zaměřena na poskytovatele internetových služeb, kteří mají pouze jeden 
-on-premise resolver a pro zajištění vysoké dostupnosti používají cloudové DNS resolvery jako sekundární rekurzivní resolver pro své zákazníky. Jedním z předpokladů je definování veřejné IP adresy 
-nebo rozsahy pro přiřazení bezpečnostní politiky coudovému resolveru, aby mohl rozlišovat a poskytovat správné zásady filtrování, které jste nastavili pro svou síť. 
+Videonávod krok za krokem si můžete prohlédnout :ref:`zde<Cloudove resolvery video>`.Whalebone Cloud DNS resolver je služba určená především pro malé nebo střední zákazníky, kteří mohou cloudové resolvery používat jako záložní resolver. Typicky je zaměřena na poskytovatele internetových služeb, kteří mají pouze jeden on-premise resolver a pro zajištění vysoké dostupnosti používají cloudové DNS resolvery jako sekundární rekurzivní resolver pro své zákazníky. Jedním z předpokladů je definování veřejné IP adresy nebo rozsahy pro přiřazení bezpečnostní politiky coudovému resolveru, aby mohl rozlišovat a poskytovat správné zásady filtrování, které jste nastavili pro svou síť. 
 
-Definice rozsahu veřejné sítě slouží k rozlišení jednotlivých zákazníků a jejich uživatelů. Je nutné zahrnout všechny rozsahy veřejné sítě, které bude resolver DNS používat, i uživatelé přistupující k internetu. Definice slouží k přizpůsobení vzhledu stránky blokování (popsáno později). Jeden zákazník může spravovat více síťových rozsahů, 
-tyto rozsahy lze přiřadit lokalitám, aby bylo možné snadno rozlišit jednotlivé síťové zóny při investigaci provozu DNS a incidentech.
+Definice rozsahu veřejné sítě slouží k rozlišení jednotlivých zákazníků a jejich uživatelů. Je nutné zahrnout všechny rozsahy veřejné sítě, které bude resolver DNS používat, i uživatelé přistupující k internetu. Definice slouží k přizpůsobení vzhledu stránky blokování (popsáno později). Jeden zákazník může spravovat více síťových rozsahů, tyto rozsahy lze přiřadit lokalitám, aby bylo možné snadno rozlišit jednotlivé síťové zóny při investigaci provozu DNS a incidentech.
 
 .. image:: ./img/client_networks.png
    :align: center
-
 
 .. warning:: Pokud nevyplníte rozsahy veřejné sítě, budou cloudové resolvery sloužit jako jednoduché DNS resolvery **bez jakéhokoli filtrování**. Pokud používáte místní resolvery, musíte stále zadávat rozsahy sítě, aby se blokovaným uživatelům zobrazovala plně přizpůsobená blokační stránka.
 
@@ -21,11 +16,14 @@ tyto rozsahy lze přiřadit lokalitám, aby bylo možné snadno rozlišit jednot
 
 .. tip:: Při testování Whalebone (např. přidáním testovací domény na blacklist) nezapomeňte, že mnoho DNS záznamů může být uloženo v cache kdekoli mezi resolverem a uživatelem (včetně prohlížeče, operačního systému nebo forwarderů). Testování ihned po změně konfigurace by proto mohlo selhat a doba, než se ochrana stane aktivní, by se mohla lišit v závislosti na TTL konkrétního záznamu DNS (pokud by všechny mezipaměti po cestě skutečně dodržovaly hodnotu TTL).
 
-Pokud je tato možnost nasazení preferována, měli byste provoz DNS přesměrovat na cloudové resolvery Whalebone. Cloudové resolvery jsou k dispozici anycast IP adrese
-**193.32.92.32** a **193.32.92.33**.
+Pokud je tato možnost nasazení preferována, měli byste provoz DNS přesměrovat na cloudové resolvery Whalebone. Cloudové resolvery jsou k dispozici anycast IP adrese **193.32.92.32** a **193.32.92.33**.
 
 .. image:: ./img/resolver_ip.png
    :align: center
 
 IP adresy resolverů jsou dostupné v části **Cloudové resolvery** a v nabídce **Nápověda** → **DNS překladače**.
 
+Cloudové resolvery také poskytují možnost používat protokol DoH (DNS over HTTPS) a DoT (DNS over TLS). DoH a DoT jsou protokoly pro provádění vzdáleného rozlišení doménových jmen (DNS) prostřednictvím protokolů HTTPS a TLS. Jsou navrženy tak, aby zvýšily soukromí a bezpečnost uživatelů tím, že zabrání odposlechu a manipulaci s daty DNS třetími stranami. Používáním DoH nebo DoT můžete zlepšit soukromí a bezpečnost svých DNS dotazů, zatímco stále využíváte funkce filtrování a ochrany nabízené cloudovými resolvery Whalebone.
+
+* DoH (DNS over HTTPS) endpoint: **https://doh.whalebone.io/dns-query**
+* DoT (DNS over TLS) endpoint: **tls://dot.whalebone.io:853**

--- a/en/cloud_resolver.rst
+++ b/en/cloud_resolver.rst
@@ -1,19 +1,12 @@
 Cloud DNS resolvers
 --------------------
 
-You can watch step-by-step video guide :ref:`here<Cloud resolvers video>`.
-Whalebone Cloud DNS resolver is a service aimed mainly for small or medium customers who can use cloud resolvers for a backup. Typically it is aimed at ISPs that have only one 
-on-premise resolver and to ensure high availability, they use cloud DNS resolvers as a secondary recursive for their customers. One of the prerequisites is to define a public IP address 
-or ranges to Cloud DNS resolver policy assignment so cloud resolver can differentiate and deliver the right filtering policy which you have setup for your network. 
+You can watch step-by-step video guide :ref:`here<Cloud resolvers video>`. Whalebone Cloud DNS resolver is a service aimed mainly for small or medium customers who can use cloud resolvers for a backup. Typically it is aimed at ISPs that have only one on-premise resolver and to ensure high availability, they use cloud DNS resolvers as a secondary recursive for their customers. One of the prerequisites is to define a public IP address or ranges to Cloud DNS resolver policy assignment so cloud resolver can differentiate and deliver the right filtering policy which you have setup for your network. 
 
-
-Public network range definition serves to distinguish individual customers and their users. It is necessary to include all the public network ranges that will be used by DNS resolver 
-as well as the users browsing the internet. The definition is used to customize the block page appearance (described later). Single customer can manage more network ranges, 
-such ranges can be assigned to localities to easily distinguish between logical network zones in DNS traffic audit and incidents.
+Public network range definition serves to distinguish individual customers and their users. It is necessary to include all the public network ranges that will be used by DNS resolver as well as the users browsing the internet. The definition is used to customize the block page appearance (described later). Single customer can manage more network ranges, such ranges can be assigned to localities to easily distinguish between logical network zones in DNS traffic audit and incidents.
 
 .. image:: ./img/client_networks.png
    :align: center
-
 
 .. warning:: If you do not fill in your public network ranges, cloud resolvers will serve as a simple DNS resolvers **without any filtering**. If you use local resolvers, you still have to input your network ranges to display fully customized blocking page to the blocked users.
 
@@ -23,12 +16,14 @@ such ranges can be assigned to localities to easily distinguish between logical 
 
 .. tip:: While testing Whalebone (e.g. through adding a testing domain into blacklist) don't forget that many DNS records could be recently in the DNS cache anywhere between the resolver and the user (including the browser, operating system or forwarders). Testing right after the configuration change could therefore fail and the timespan before the protection becomes active could vary based on the TTL of the particular DNS record (should all the caches along the way actually honor the TTL value).
 
-
-You should forward your DNS traffic towards Whalebone cloud resolvers if this is your preferred deployment option. Cloud resolvers are available on an Anycasted IP address
-**193.32.92.32** and **193.32.92.33**.
+You should forward your DNS traffic towards Whalebone cloud resolvers if this is your preferred deployment option. Cloud resolvers are available on an Anycasted IP address **193.32.92.32** and **193.32.92.33**.
 
 .. image:: ./img/resolver_ip.png
    :align: center
 
 The IP addresses of the resolvers are accessible under **Cloud resolvers** and under the menu **Help** → **DNS resolvers**.
 
+Cloud resolvers also provide a possibility to use DoH (DNS over HTTPS) protocol and DoT (DNS over TLS) protocol. DoH and DoT are protocols for performing remote Domain Name System (DNS) resolution via the HTTPS and TLS protocols, respectively. They are designed to increase user privacy and security by preventing eavesdropping and manipulation of DNS data by third parties. By using DoH or DoT, you can enhance the privacy and security of your DNS queries while still benefiting from the filtering and protection features offered by Whalebone cloud resolvers.
+
+* DoH (DNS over HTTPS) endpoint: **https://doh.whalebone.io/dns-query**
+* DoT (DNS over TLS) endpoint: **tls://dot.whalebone.io:853**


### PR DESCRIPTION
I had to create a new pull request for this change because the previous one used the wrong source page, which included changes from a different branch.