### PR TITLE
Add resolver changelog

### DIFF
--- a/cs/index_aura.rst
+++ b/cs/index_aura.rst
@@ -26,6 +26,7 @@ Další informace o produktu a společnosti jsou k dispozici na oficiálních st
 
    local_resolver
    resolvers
+   resolver_changelog
    security_policies
    dns_resolution
    knot_tips_tricks

--- a/cs/index_immunity.rst
+++ b/cs/index_immunity.rst
@@ -26,6 +26,7 @@ Další informace o produktu a společnosti jsou k dispozici na oficiálních st
 
    local_resolver
    resolvers
+   resolver_changelog
    security_policies
    dns_resolution
    knot_tips_tricks

--- a/cs/index_peacemaker.rst
+++ b/cs/index_peacemaker.rst
@@ -26,6 +26,7 @@ Další informace o produktu a společnosti jsou k dispozici na oficiálních st
 
    local_resolver
    resolvers
+   resolver_changelog
    security_policies
    dns_resolution
    knot_tips_tricks

--- a/cs/resolver_changelog.rst
+++ b/cs/resolver_changelog.rst
@@ -1,0 +1,426 @@
+***********************
+Přehled verzí resolveru
+***********************
+
+Tato stránka obsahuje poznámky k jednotlivým verzím Whalebone Resolveru určené
+zákazníkům. Před aktualizací si přečtěte požadavky a poznámky k cílové verzi.
+
+Resolver 3.4.1
+==============
+
+Požadavky před aktualizací
+--------------------------
+
+.. important::
+
+   **Je vyžadován Docker Engine 24.0 nebo novější.**
+
+   Tato verze není kompatibilní s Docker Engine 23.0 a staršími verzemi. Před
+   aktualizací resolveru ověřte, že server používá Docker Engine 24.0 nebo
+   novější. V opačném případě může aktualizace selhat a resolver může skončit ve
+   stavu **Nedostupný**, jehož oprava vyžaduje ruční zásah na serveru.
+
+   Virtualizované prostředí musí virtuálnímu stroji zpřístupnit požadované
+   instrukce CPU x86-64-v2 nebo x86-64-v3, včetně AES. V opačném případě může
+   resolver selhat kvůli závislosti použité knihovny.
+
+Hlavní změny
+------------
+
+* **Bezpečnostní opravy a vyšší spolehlivost DNSSEC:** Verze obsahuje důležité
+  bezpečnostní opravy DNS enginu, včetně oprav problémů v DNS-over-QUIC, které
+  by v dotčených konfiguracích mohly umožnit vzdálené spuštění kódu. Zlepšuje
+  také fungování DNSSEC v okrajových případech agresivního využití mezipaměti a
+  aktualizuje certifikát IANA používaný k ustavení důvěry s kořenovou zónou.
+* **Opravy chování DNS protokolu a resolveru:** Zlepšuje chování mezipaměti pro
+  DoH, zpracování DNS64/CNAME, odpovědi EDNS BADVERS a vybrané okrajové případy
+  local-data a RPZ.
+
+Resolver 3.4.0
+==============
+
+Požadavky před aktualizací
+--------------------------
+
+.. important::
+
+   **Je vyžadován Docker Engine 24.0 nebo novější.**
+
+   Tato verze není kompatibilní s Docker Engine 23.0 a staršími verzemi. Před
+   aktualizací resolveru ověřte, že server používá Docker Engine 24.0 nebo
+   novější. Virtualizované prostředí musí zpřístupnit instrukce x86-64-v2 nebo
+   x86-64-v3, včetně AES.
+
+Hlavní změny
+------------
+
+Tato verze zlepšuje efektivitu aktualizací databází a provozní spolehlivost.
+
+* **Flexibilnější kontrola místa na disku při aktualizaci:** Aktualizaci lze po
+  ruční konfiguraci povolit i v nasazeních, která nesplňují minimální požadavek
+  na místo na disku. Pro stabilní provoz důrazně doporučujeme splnit
+  dokumentované hardwarové požadavky.
+* **Efektivnější stahování databází:** Databáze se stahují a spravují samostatně
+  pro jednotlivá databázová prostředí. Stahují se pouze změněné části.
+* **Lepší souběžný provoz služeb:** HTTP a HTTPS služby blokační stránky lze
+  navázat na konkrétní IP adresy, což usnadňuje provoz dalších služeb, například
+  DoH, na stejném serveru.
+* **Opravy provozní spolehlivosti:** Zlepšuje nastavení velikosti mezipaměti,
+  kontroly časových razítek LMDB, restartování kontejnerů resolveru, sběr
+  statistik Dockeru a ladicí logování blokační stránky.
+
+.. only:: Aura
+
+   * **Filtrování provozu RADIUS a Diameter:** Účetní provoz lze před předáním
+     filtrovat pomocí konfigurovatelných pravidel atributů a AVP.
+   * **Podpora pasivního listeneru Diameter:** Resolver může zpracovávat
+     zrcadlený provoz Diameter CCR bez odesílání odpovědí.
+
+Poznámky
+--------
+
+* Při aktualizaci se existující struktura databázové mezipaměti automaticky
+  převede na novou strukturu rozdělenou podle databázového prostředí.
+* Pokud je kontrola místa na disku obejita, může resolver běžet pod doporučenými
+  požadavky. Tuto možnost používejte pouze v prověřených prostředích.
+* Po aktualizaci se může zvýšit využití paměti. Jde o očekávané chování, protože
+  konfigurace mezipaměti se nyní aplikuje správně a mezipaměť je uložena v RAM.
+
+Resolver 3.3.0
+==============
+
+.. only:: Immunity or Peacemaker
+
+   Požadavky před aktualizací
+   --------------------------
+
+   .. important::
+
+      Je vyžadován Docker Engine 24.0 nebo novější. Virtualizované prostředí
+      musí zpřístupnit instrukce x86-64-v2, včetně AES.
+
+   Tato verze zlepšuje rozsah blokování, logování DNS provozu, aktualizace v
+   reálném čase a provozní bezpečnost.
+
+   * **Širší rozsah blokování:** Resolver blokuje domény pro více typů DNS
+     dotazů, včetně TXT a CNAME.
+   * **Rozšířené řízení logování DNS:** Volitelná anonymizace, deduplikace a
+     vzorkování usnadňují práci s logy.
+   * **Více aktualizací informací o hrozbách v reálném čase:** Resolver přijímá
+     více indikátorů hrozeb průběžně.
+   * **Rychlejší aktualizace politik:** Podporované změny politik a konfigurace
+     se přenášejí přímo do resolverů.
+   * **Bezpečnější aktualizace a provoz:** Přidává kontroly disku a rotace logů,
+     kontrolu funkčnosti blokování, lepší obnovu a plynulejší metriky po restartu.
+
+   .. note::
+
+      Po aktualizaci mohou být některé místní logy jednorázově zpracovány znovu,
+      což může dočasně vytvořit duplicitní exportované záznamy. DNS a blokování
+      nejsou ovlivněny.
+
+.. only:: Aura
+
+   Tato verze zlepšuje rozsah blokování, práci s identitou, logování DNS
+   provozu, aktualizace politik v reálném čase a provozní bezpečnost.
+
+   * **Širší rozsah blokování:** Resolver může blokovat domény bez ohledu na typ
+     DNS dotazu, včetně moderních typů, například HTTPS.
+   * **Podpora identity Cisco EDNS0:** Resolver může získat identitu zařízení z
+     nakonfigurovaných dat EDNS0 a použít ji při přiřazení politiky.
+   * **Rozšířené řízení logování DNS:** Přidává volitelnou anonymizaci,
+     deduplikaci a vzorkování.
+   * **Rychlejší aktualizace politik:** Podporované změny politik a konfigurace
+     se přenášejí přímo do resolverů.
+   * **Bezpečnější aktualizace a provoz:** Přidává kontroly disku a rotace logů,
+     kontrolu funkčnosti blokování, lepší obnovu a plynulejší metriky po restartu.
+
+   .. note::
+
+      Po aktualizaci mohou být některé místní logy jednorázově zpracovány znovu,
+      což může dočasně vytvořit duplicitní exportované záznamy. DNS a blokování
+      nejsou ovlivněny.
+
+Resolver 3.2.0
+==============
+
+Pokročilá ochrana před hrozbami
+-------------------------------
+
+* **Kontrola CNAME řetězce:** Resolver při zpracování DNS dotazů kontroluje celý
+  řetězec CNAME až do hloubky deseti úrovní.
+* **Blokování hrozeb v TXT záznamech:** TXT dotazy na domény označené jako
+  hrozby jsou aktivně blokovány.
+
+Lepší viditelnost a logování
+----------------------------
+
+* **Podrobnější logy hrozeb a obsahu:** Exportované logy obsahují protokol,
+  ``qclass`` a ``ede_code``.
+
+Protokoly a uživatelská zkušenost
+---------------------------------
+
+* **Podpora DNS-over-QUIC (Beta):** DNS engine byl aktualizován na Knot Resolver
+  6.2.0 a přidává předběžnou podporu DNS-over-QUIC. Beta verzi testujte pouze v
+  nekritických prostředích.
+* **Úprava YouTube Safe Search:** YouTube a související domény byly odebrány ze
+  seznamu vynuceného Safe Search, aby byl obnoven přístup k živým přenosům.
+
+Resolver 3.1.4
+==============
+
+* Zlepšena stabilita při vysoké DNS zátěži.
+* Opraven vzácný problém se zamknutím databáze mezipaměti.
+
+Resolver 3.1.3
+==============
+
+Tato verze opravuje chování mezipaměti Knot Resolveru, které mohlo příliš dlouho
+uchovávat prázdné DNS odpovědi (NOERROR/NODATA) a způsobovat přetrvávající
+výpadky po dočasných problémech upstream serveru.
+
+* **Oprava:** Prázdné odpovědi se již neukládají s nepřiměřeně dlouhým TTL.
+* **Výsledek:** Omezuje případy, kdy se doména obnoví až po vyčištění mezipaměti
+  nebo změně resolveru.
+* **Dopad:** Zlepšuje stabilitu DNS při dočasných problémech upstream nebo
+  autoritativních serverů.
+* **Doporučení:** Změna konfigurace není nutná. Po nasazení lze volitelně
+  vyčistit mezipaměť.
+
+Resolver 3.1.1
+==============
+
+* **Bezpečnější aktualizace a návrat k předchozí verzi:** Resolver se vrátí do
+  funkčního stavu i po nasazení neplatné konfigurace.
+* **Spolehlivější monitoring:** Opravuje chybějící metriky po neúspěšné
+  aktualizaci a návratu k předchozí verzi.
+* **Čistší provoz:** Omezuje zbytečné chyby tam, kde se nepoužívá volitelné
+  logování dnstag/dnstap.
+* **Blokační stránka ve veřejném cloudu:** Opravuje vzácné zobrazení nesprávného
+  zákaznického brandingu.
+* **Vyšší odolnost:** Zlepšuje automatickou obnovu po vzácných problémech s
+  databází nebo načtením dat.
+
+Resolver 3.0.1
+==============
+
+Požadavky před aktualizací
+--------------------------
+
+.. important::
+
+   Je vyžadován Docker Engine 24.0 nebo novější. Virtualizované prostředí musí
+   zpřístupnit instrukce x86-64-v2, včetně AES.
+
+Opravy
+------
+
+* **Odolnost resolveru:** Opravuje dvě vzácné situace, které mohly při
+  zpracování neobvyklých DNS zpráv způsobit ukončení resolveru. Změna
+  konfigurace není nutná.
+
+Resolver 3.0.0
+==============
+
+Požadavky před aktualizací
+--------------------------
+
+.. warning::
+
+   Tato verze není kompatibilní s předáváním DNS dotazů pro doménu ``.local``.
+
+.. important::
+
+   Je vyžadován Docker Engine 24.0 nebo novější. Virtualizované prostředí musí
+   zpřístupnit instrukce x86-64-v2, včetně AES.
+
+Nové funkce
+-----------
+
+* Vynucení Safe Search.
+* Odkládání zátěže podle využití CPU.
+* Omezení rychlosti DNS dotazů.
+* Statické DNS záznamy podporují všechny typy záznamů.
+
+Změny
+-----
+
+* Přidána podpora Knot Resolveru 6.x a aktualizace na verzi 6.0.14.
+* Přidána detekce pádů pro Knot Resolver 5 a 6.
+* Do zpráv dnstap přidán příznak ``ratelimited``.
+* Přidána podpora Safe Search pro klienty s filtrováním obsahu.
+* Agent používá Ubuntu 24.04 a Python 3.12.
+* Statistiky resolveru se sbírají přes řídicí socket.
+* Zlepšena spolehlivost UNIX socketů a mazání mezipaměti jedné domény.
+
+Resolver 2.1.7
+==============
+
+Tato verze se zaměřuje na bezpečnostní opravy a správné fungování DNSSEC.
+
+* Opravuje okrajové případy agresivního využití mezipaměti při zpracování RRSIG
+  a následujícího názvu NSEC.
+* Aktualizuje certifikát IANA používaný k ustavení důvěry s kořenovou zónou.
+* Zlepšuje DNSSEC odpovědi s prázdnými sekcemi ANSWER a AUTHORITY.
+* Vylepšuje chování mezipaměti pro DoH.
+
+Resolver 2.1.6
+==============
+
+* Zlepšuje chování sinkhole pro požadavky na záznamy HTTPS. Uživatelské a
+  výchozí hodnoty sinkhole IPv4 a IPv6 se aplikují konzistentněji.
+
+Resolver 2.1.5
+==============
+
+* Zlepšena stabilita při vysoké DNS zátěži.
+* Opraven vzácný problém se zamknutím databáze mezipaměti.
+
+Resolver 2.1.4
+==============
+
+Tato verze opravuje chování mezipaměti Knot Resolveru, které mohlo příliš dlouho
+uchovávat prázdné DNS odpovědi (NOERROR/NODATA).
+
+* Prázdné odpovědi se již neukládají s nepřiměřeně dlouhým TTL.
+* Zlepšuje stabilitu při dočasných problémech upstream nebo autoritativních
+  serverů.
+* Změna konfigurace není nutná. Po nasazení lze volitelně vyčistit mezipaměť.
+
+Resolver 2.1.1
+==============
+
+Požadavky před aktualizací
+--------------------------
+
+.. important::
+
+   Je vyžadován Docker Engine 24.0 nebo novější. Virtualizované prostředí musí
+   zpřístupnit instrukce x86-64-v2, včetně AES.
+
+* Opravuje dvě vzácné situace, které mohly při zpracování neobvyklých DNS zpráv
+  způsobit ukončení resolveru.
+* Změna konfigurace není nutná.
+
+Resolver 2.1.0
+==============
+
+Požadavky před aktualizací
+--------------------------
+
+.. important::
+
+   Je vyžadován Docker Engine 24.0 nebo novější. Virtualizované prostředí musí
+   zpřístupnit instrukce x86-64-v2, včetně AES.
+
+Nové funkce
+-----------
+
+* Opravuje zranitelnost DNSSEC.
+* Přidává EDE kódy, protokol, ``qclass`` a dobu odpovědi do logů a dnstap.
+* Přidává mechanismus pro sdílení rozšířených logů.
+* Vylučuje z logů provoz ``connectivity-check.whalebone.io``.
+* Přidává anonymizaci IP adres klientů.
+* Přidává volby pro zpřísnění TLS interní komunikace.
+* Přidává identifikaci zákazníka podle prefixu IPv6.
+
+Změny
+-----
+
+* Aktualizuje Knot Resolver na 5.7.5 a LMDB na 0.9.33.
+* Rozšiřuje pasivní DNS logy o omezení rychlosti a diagnostická pole.
+* Mění názvy výstupních souborů logcat na formát ``-<date>.ndjson``.
+* Odstraňuje zastaralé proměnné prostředí související s NATS.
+
+Resolver 2.0.1
+==============
+
+* Vrací Python agenta na verzi 3.8 kvůli kompatibilitě s Docker Engine 23.0 a
+  staršími verzemi.
+
+.. warning::
+
+   Následující verze vyžaduje Docker Engine 24.0 nebo novější. Před aktualizací
+   z Resolveru 2.0.1 aktualizujte Docker.
+
+Resolver 2.0.0
+==============
+
+.. warning::
+
+   Před aktualizací resolveru aktualizujte Docker Engine na verzi 24.0 nebo
+   novější.
+
+Hlavní změny
+------------
+
+* Zlepšuje záložní chování při poškození stažených databází.
+* Přidává čas vytvoření databází do informací o stavu resolveru.
+* Přidává podporu DNS dotazů za CGNAT.
+* Přidává značky politik do dnstap a logů hrozeb a obsahu.
+* Uchovává ETag databází i po restartu služeb.
+* Přidává volitelné reverzní vyhledávání IP a konfigurovatelné filtrování logů.
+* Předává zdrojový port HTTP požadavku funkci bypass blokační stránky.
+* Zlepšuje kontroly stavu kontejnerů, místní API, práci s databázemi a souběžný
+  přístup k LMDB.
+* Odstraňuje tlačítko bypass ze stránek deny listu a zákonem nařízeného
+  blokování.
+
+Starší verze Resolveru 1.x
+==========================
+
+Resolver 1.x již není podporován. Následující historické verze jsou uvedeny pro
+referenci.
+
+Resolver 1.0.93
+---------------
+
+* Při zjištění poškozených nebo chybějících databází při startu se jejich
+  načtení přeskočí a v adresáři mezipaměti se vytvoří prázdné databáze.
+
+Resolver 1.0.92
+---------------
+
+* Aktualizuje Knot Resolver na 5.7.4, přidává kořenový klíč DNSSEC KSK-2024 a
+  omezuje buffering, který mohl přispívat k DoS přes TCP.
+* Zlepšuje inicializaci, čištění a souběžné aktualizace databází.
+* Přidává statistiky návštěv blokační stránky a vyžaduje TLS 1.2 nebo novější.
+* Přepisuje komponenty kresman a consumer do jazyka Go pro lepší výkon a správu
+  paměti.
+
+Resolver 1.0.91
+---------------
+
+* Zlepšuje výkon consumeru a opravuje únik paměti.
+* Zlepšuje správu databází a přidává konfigurovatelný počet gRPC streamů.
+* Zajišťuje bezpečný souběžný přístup k mezipaměti certifikátů.
+
+Resolver 1.0.89
+---------------
+
+* Aktualizuje Knot Resolver na 5.7.4 kvůli bezpečnostní opravě, omezení TCP
+  bufferu a přidání kořenového klíče DNSSEC KSK-2024.
+
+Resolver 1.0.87
+---------------
+
+* Opravuje přiřazení logů cloudových resolverů a zpracování škodlivých
+  neexistujících domén.
+* Otevírá logy dnstag v režimu přidávání kvůli rotaci logů a snížení využití CPU.
+
+Resolver 1.0.84
+---------------
+
+* Přidává statistiky návštěv blokační stránky.
+* Aktualizuje Knot Resolver na 5.7.3 a zlepšuje práci s databázemi při startu.
+* Zabraňuje zaplnění disku dočasnými soubory při stahování databází.
+* Zpřísňuje TLS blokační stránky na TLS 1.2 nebo novější.
+
+Resolver 1.0.82
+---------------
+
+* Zavádí samostatné verzování komponent se závislostmi na softwaru třetích stran.
+* Přidává podepsané obrazy kontejnerů, lepší zamykání a správu databází,
+  konfigurovatelnou dobu bypassu a metriky blokační stránky.
+* Přidává názvy hostitelů do logů hrozeb a zlepšuje stabilitu spojení.

--- a/en/index_aura.rst
+++ b/en/index_aura.rst
@@ -26,6 +26,7 @@ More information about the product and company is available on the official `Wha
 
    local_resolver
    resolvers
+   resolver_changelog
    security_policies
    dns_resolution
    knot_tips_tricks

--- a/en/index_immunity.rst
+++ b/en/index_immunity.rst
@@ -26,6 +26,7 @@ More information about the product and company is available on the official `Wha
 
    local_resolver
    resolvers
+   resolver_changelog
    security_policies
    dns_resolution
    knot_tips_tricks

--- a/en/index_peacemaker.rst
+++ b/en/index_peacemaker.rst
@@ -26,6 +26,7 @@ More information about the product and company is available on the official `Wha
 
    local_resolver
    resolvers
+   resolver_changelog
    security_policies
    dns_resolution
    knot_tips_tricks

--- a/en/resolver_changelog.rst
+++ b/en/resolver_changelog.rst
@@ -1,0 +1,442 @@
+******************
+Resolver changelog
+******************
+
+This page contains customer-facing release notes for Whalebone Resolver.
+Before upgrading, review the requirements and notes for the target version.
+
+Resolver 3.4.1
+==============
+
+Required before upgrade
+-----------------------
+
+.. important::
+
+   **Docker Engine 24.0 or newer is required.**
+
+   This release is not compatible with Docker Engine 23.0 and earlier. Before
+   upgrading the resolver, make sure the server is running Docker Engine 24.0
+   or newer. Otherwise, the upgrade may fail and the resolver may end up in an
+   **Unavailable** state, requiring manual intervention on the server.
+
+   Virtualized environments must expose the required x86-64-v2 or x86-64-v3
+   CPU instructions, including AES, to the virtual machine. Otherwise, the
+   resolver may fail because of a library dependency.
+
+Release highlights
+------------------
+
+* **Security and DNSSEC reliability fixes:** Includes important upstream
+  security fixes in the resolver engine, including DNS-over-QUIC issues that
+  could allow remote code execution in affected configurations. It also
+  improves DNSSEC correctness in aggressive-caching edge cases and updates the
+  IANA certificate used during root trust-anchor bootstrapping.
+* **Resolver protocol and DNS behavior fixes:** Improves DoH cache-control
+  behavior, DNS64/CNAME handling, EDNS BADVERS responses, and selected
+  local-data and RPZ edge cases. These changes improve resolver correctness and
+  standards compliance in specific DNS scenarios.
+
+Resolver 3.4.0
+==============
+
+Required before upgrade
+-----------------------
+
+.. important::
+
+   **Docker Engine 24.0 or newer is required.**
+
+   This release is not compatible with Docker Engine 23.0 and earlier. Before
+   upgrading the resolver, make sure the server is running Docker Engine 24.0
+   or newer. Otherwise, the upgrade may fail and the resolver may end up in an
+   **Unavailable** state, requiring manual intervention on the server.
+
+   Virtualized environments must expose the required x86-64-v2 or x86-64-v3
+   CPU instructions, including AES, to the virtual machine.
+
+Release highlights
+------------------
+
+This release improves database update efficiency and operational reliability.
+
+* **Flexible upgrade handling for disk-space requirements:** Resolver upgrades
+  can be allowed after manual configuration when a deployment does not meet the
+  minimum disk-space requirement. Meeting the documented minimum hardware
+  requirements is still strongly recommended for stable operation.
+* **More efficient database downloads:** Resolver databases are downloaded and
+  managed per database environment. Only changed database parts are
+  downloaded, reducing unnecessary full database transfers.
+* **Improved service coexistence on resolver hosts:** Blocking-page HTTP and
+  HTTPS listeners can bind to specific IP addresses, making it easier to run
+  the blocking page alongside services such as DoH on the same host.
+* **Operational reliability fixes:** Improves cache sizing, LMDB timestamp
+  checks, resolver-container restart behavior, Docker statistics collection,
+  and blocking-page debug logging.
+
+.. only:: Aura
+
+   * **RADIUS and Diameter traffic filtering:** Accounting traffic can be
+     filtered before forwarding using configurable attribute and AVP rules.
+   * **Passive Diameter listener support:** Resolver deployments can process
+     mirrored Diameter CCR traffic without sending responses.
+
+Notes
+-----
+
+* During upgrade, the existing resolver database cache layout is migrated
+  automatically to the new per-environment structure. No manual migration is
+  expected during the standard upgrade path.
+* If disk-space validation is bypassed, the resolver may still be running below
+  the recommended storage requirements. Use this only in controlled and
+  reviewed environments.
+* Resolver memory usage may increase after upgrade. This is expected because
+  the cache configuration is now applied correctly and the cache is stored in
+  memory. A larger cache can improve the cache hit ratio and performance.
+
+Resolver 3.3.0
+==============
+
+.. only:: Immunity or Peacemaker
+
+   Required before upgrade
+   -----------------------
+
+   .. important::
+
+      Docker Engine 24.0 or newer is required. Virtualized environments must
+      expose the required x86-64-v2 CPU instructions, including AES.
+
+   This release improves blocking coverage, DNS traffic logging, real-time
+   updates, and operational safety.
+
+   * **Stronger blocking coverage:** Domains are blocked across more DNS query
+     types, including TXT and CNAME.
+   * **Enhanced DNS traffic logging controls:** Optional anonymization,
+     deduplication, and sampling make logs easier to use for reporting,
+     troubleshooting, and high-volume operations.
+   * **More real-time threat-intelligence updates:** Resolvers receive more
+     threat indicators in real time.
+   * **Faster policy updates:** Supported policy and configuration changes are
+     streamed directly to resolvers.
+   * **Safer upgrades and operations:** Adds pre-upgrade disk and log-rotation
+     validation, blocking health checks, improved recovery behavior, and
+     smoother metrics after resolver restarts.
+
+   .. note::
+
+      After upgrade, some existing local log files may be processed once more,
+      temporarily duplicating exported logs. DNS resolution and blocking are
+      not affected.
+
+.. only:: Aura
+
+   This release improves blocking coverage, identity handling, DNS traffic
+   logging, real-time policy updates, and operational safety.
+
+   * **Stronger blocking coverage:** Domains can be blocked regardless of DNS
+     query type, including modern query types such as HTTPS.
+   * **Cisco EDNS0 identity support:** The resolver can extract device identity
+     from configured EDNS0 packet data and use it for policy matching.
+   * **Enhanced DNS traffic logging controls:** Adds optional anonymization,
+     deduplication, and sampling.
+   * **Faster policy updates:** Supported policy and configuration changes are
+     streamed directly to resolvers.
+   * **Safer upgrades and operations:** Adds pre-upgrade disk and log-rotation
+     validation, blocking health checks, improved recovery behavior, and
+     smoother metrics after resolver restarts.
+
+   .. note::
+
+      After upgrade, some existing local log files may be processed once more,
+      temporarily duplicating exported logs. DNS resolution and blocking are
+      not affected.
+
+Resolver 3.2.0
+==============
+
+Advanced threat protection
+--------------------------
+
+* **Deep CNAME inspection:** The resolver inspects the complete CNAME chain, up
+  to ten levels deep, when processing DNS requests.
+* **TXT-record threat blocking:** TXT queries to domains identified as threats
+  are actively blocked, helping prevent command-and-control communication and
+  data exfiltration.
+
+Enhanced visibility and logging
+-------------------------------
+
+* **Richer threat and content logs:** Exported logs include the protocol,
+  ``qclass``, and ``ede_code`` fields.
+
+Protocol upgrades and user experience
+-------------------------------------
+
+* **DNS-over-QUIC support (Beta):** The DNS engine was upgraded to Knot Resolver
+  6.2.0, adding early support for DNS-over-QUIC. Test this beta feature in
+  non-critical environments.
+* **YouTube Safe Search update:** YouTube and related domains were removed from
+  the enforced Safe Search list to restore access to YouTube live streams.
+
+Resolver 3.1.4
+==============
+
+* Improved stability under heavy DNS traffic.
+* Fixed rare cache database locking issues.
+
+Resolver 3.1.3
+==============
+
+This release fixes Knot Resolver caching behavior that could keep empty DNS
+answers (NOERROR/NODATA) cached for too long, causing persistent resolution
+failures after transient upstream issues.
+
+* **Fix:** Empty responses no longer persist with an unexpectedly long TTL.
+* **Result:** Reduces cases where affected domains recover only after a cache
+  flush or switching resolvers.
+* **Impact:** Improves DNS resolution stability during transient upstream or
+  authoritative-server anomalies and reduces the need for manual cache clearing.
+* **Recommendation:** No configuration changes are required. Temporary TTL caps
+  used only as a workaround can be reviewed after upgrade. Optionally flush the
+  cache after deployment to clear already-stuck entries sooner.
+
+Resolver 3.1.1
+==============
+
+* **Safer upgrades and rollbacks:** Hardens rollback flows so the resolver
+  returns to a working state even if an invalid configuration is deployed.
+* **More reliable monitoring:** Fixes an edge case where resolver metrics could
+  disappear after a failed upgrade and rollback.
+* **Cleaner operations:** Reduces noisy errors where optional dnstag/dnstap
+  logging is not used.
+* **Public-cloud blocking page:** Fixes a rare case where incorrect customer
+  branding could be shown.
+* **Improved resilience:** Improves automatic recovery after rare database or
+  load failures.
+
+Resolver 3.0.1
+==============
+
+Required before upgrade
+-----------------------
+
+.. important::
+
+   Docker Engine 24.0 or newer is required. Virtualized environments must
+   expose x86-64-v2 CPU instructions, including AES.
+
+Fixed
+-----
+
+* **Resolver robustness:** Fixes two rare conditions that could cause the
+  resolver to exit while processing unusual DNS messages. No configuration
+  changes are required.
+
+Resolver 3.0.0
+==============
+
+Required before upgrade
+-----------------------
+
+.. warning::
+
+   This release is not compatible with DNS forwarding for the ``.local``
+   domain.
+
+.. important::
+
+   Docker Engine 24.0 or newer is required. Virtualized environments must
+   expose x86-64-v2 CPU instructions, including AES.
+
+New features
+------------
+
+* Safe Search enforcement.
+* CPU-aware deferring.
+* DNS rate limiting.
+* Static DNS records support all record types.
+
+Changes
+-------
+
+* Added support for Knot Resolver 6.x and upgraded to Knot Resolver 6.0.14.
+* Added crash detection for Knot Resolver 5 and 6.
+* Added the ``ratelimited`` flag to dnstap messages.
+* Added Safe Search support for content-filtered clients.
+* Updated the agent base image to Ubuntu 24.04 and Python 3.12.
+* Resolver statistics are collected through the management socket.
+* Improved UNIX-socket reliability and single-domain cache clearing.
+
+Resolver 2.1.7
+==============
+
+This release focuses on upstream security and DNSSEC correctness fixes.
+
+* Fixes aggressive-caching edge cases in RRSIG label and NSEC next-name
+  handling.
+* Updates the IANA certificate used during root trust-anchor bootstrapping.
+* Improves DNSSEC responses with empty ANSWER and AUTHORITY sections.
+* Improves DoH cache-control behavior.
+
+Resolver 2.1.6
+==============
+
+* Improved HTTPS sinkhole behavior for HTTPS-record requests. User-defined and
+  default IPv4 and IPv6 sinkhole values are applied more consistently.
+
+Resolver 2.1.5
+==============
+
+* Improved stability under heavy DNS traffic.
+* Fixed rare cache database locking issues.
+
+Resolver 2.1.4
+==============
+
+This release fixes Knot Resolver caching behavior that could keep empty DNS
+answers (NOERROR/NODATA) cached for too long.
+
+* Corrects handling of cached empty responses so they do not persist with an
+  unexpectedly long TTL.
+* Improves stability during transient upstream or authoritative-server issues.
+* No configuration changes are required. Optionally flush the cache after
+  deployment to clear already-stuck entries sooner.
+
+Resolver 2.1.1
+==============
+
+Required before upgrade
+-----------------------
+
+.. important::
+
+   Docker Engine 24.0 or newer is required. Virtualized environments must
+   expose x86-64-v2 CPU instructions, including AES.
+
+* Fixes two rare conditions that could cause the resolver to exit while
+  processing unusual DNS messages.
+* No configuration changes are required.
+
+Resolver 2.1.0
+==============
+
+Required before upgrade
+-----------------------
+
+.. important::
+
+   Docker Engine 24.0 or newer is required. Virtualized environments must
+   expose x86-64-v2 CPU instructions, including AES.
+
+New features
+------------
+
+* Fixes a DNSSEC vulnerability.
+* Adds EDE codes, protocol, ``qclass``, and response time to logs and dnstap.
+* Adds a mechanism for sharing extended log data.
+* Excludes ``connectivity-check.whalebone.io`` traffic from logs.
+* Adds client-IP anonymization support.
+* Adds TLS-hardening options for internal communication.
+* Adds IPv6-prefix-based customer identity support.
+
+Changes
+-------
+
+* Upgrades Knot Resolver to 5.7.5 and LMDB to 0.9.33.
+* Extends passive DNS logs with rate-limiting and diagnostic fields.
+* Changes logcat output filenames to use a ``-<date>.ndjson`` suffix.
+* Removes deprecated NATS-related environment variables.
+
+Resolver 2.0.1
+==============
+
+* Rolls the agent's Python version back to 3.8 for compatibility with Docker
+  Engine 23.0 and earlier.
+
+.. warning::
+
+   The next release requires Docker Engine 24.0 or newer. Upgrade Docker before
+   upgrading beyond Resolver 2.0.1.
+
+Resolver 2.0.0
+==============
+
+.. warning::
+
+   Upgrade Docker Engine to version 24.0 or newer before upgrading the
+   resolver.
+
+Highlights
+----------
+
+* Improves fallback behavior when downloaded databases are corrupted.
+* Adds database creation timestamps to resolver status information.
+* Adds support for DNS requests originating behind CGNAT.
+* Adds policy tags to dnstap, threat, and content logs.
+* Persists database ETags across service restarts.
+* Adds optional reverse-IP lookup and configurable log filtering.
+* Passes the HTTP originator port to blocking-page bypass requests.
+* Improves container health checks, local API reliability, database handling,
+  and concurrent LMDB access.
+* Removes the bypass button from deny-list and legally mandated blocking pages.
+
+Legacy Resolver 1.x
+===================
+
+Resolver 1.x is end of life. The following historical releases are included for
+reference.
+
+Resolver 1.0.93
+---------------
+
+* If corrupted or missing databases are detected at startup, they are skipped
+  and empty databases are initialized in the cache directory.
+
+Resolver 1.0.92
+---------------
+
+* Upgrades Knot Resolver to 5.7.4, adds the KSK-2024 DNSSEC root key, and
+  reduces buffering that could contribute to TCP denial-of-service conditions.
+* Improves database initialization, cleanup, and concurrent update handling.
+* Adds blocking-page visit statistics and strengthens blocking-page TLS
+  configuration to require TLS 1.2 or newer.
+* Rewrites kresman and consumer components in Go for improved performance and
+  memory management.
+
+Resolver 1.0.91
+---------------
+
+* Improves consumer performance and fixes a memory leak.
+* Improves database lifecycle handling and configurable gRPC streams.
+* Makes generated-certificate cache access thread-safe.
+
+Resolver 1.0.89
+---------------
+
+* Upgrades Knot Resolver to 5.7.4 to address a security vulnerability, reduce
+  TCP buffering, and add the KSK-2024 DNSSEC root key.
+
+Resolver 1.0.87
+---------------
+
+* Fixes cloud-resolver log attribution and handling of malicious,
+  non-existent domains.
+* Opens dnstag logs in append mode to support log rotation and reduce CPU use.
+
+Resolver 1.0.84
+---------------
+
+* Adds blocking-page visit statistics.
+* Upgrades Knot Resolver to 5.7.3 and improves startup database handling.
+* Prevents temporary database-download artifacts from filling disk space.
+* Strengthens blocking-page TLS configuration to require TLS 1.2 or newer.
+
+Resolver 1.0.82
+---------------
+
+* Introduces component-specific versioning for components with third-party
+  dependencies.
+* Adds signed container images, improved database locking and lifecycle
+  handling, configurable bypass duration, and blocking-page metrics.
+* Adds hostname enrichment to threat logs and improves connection stability.


### PR DESCRIPTION
Jira: https://whaleboneio.atlassian.net/browse/PD-14616 PD-14616

## What changed

- add customer-facing resolver changelog pages in English and Czech
- include release notes from Resolver 3.4.1 through the legacy 1.x series
- show Aura-specific and Immunity/Peacemaker-specific notes using Sphinx product conditions
- add the changelog to the Aura, Immunity, and Peacemaker navigation in both languages
- omit empty drafts, skipped releases, missing-note placeholders, internal Jira links, and reviewer comments from the source document

## Why

Customers need a product-appropriate resolver release history directly in the public documentation, available in both supported languages.

## Impact

Aura, Immunity, and Peacemaker documentation will expose the new resolver changelog under Configuration. Product-specific releases render only the notes relevant to that product.

## Validation

- confirmed local `master` was up to date with `origin/master` before branching
- built English and Czech documentation for Aura, Immunity, and Peacemaker with Sphinx
- verified Aura-only RADIUS, Diameter, and Cisco EDNS0 notes do not render for Immunity
- ran `git diff --check`
- no new Sphinx warnings; only existing repository `toc.not_included` warnings remain